### PR TITLE
Add test to verify postgres uses config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,3 +33,30 @@ jobs:
     - name: Run tests
       run: |
         uv run pytest -vvv
+
+  integration-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        
+    - name: Install uv
+      run: |
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        
+    - name: Install dependencies
+      run: |
+        uv sync
+        
+    - name: Run integration tests
+      run: |
+        uv run pytest -vvv -m "integration"

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,11 +22,17 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 # Create a working directory for the package
 WORKDIR /app
 
-# Copy the package files
+# Install dependencies using uv
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --frozen --active --no-install-project
+
 COPY . .
 
-# Install dependencies using uv
-RUN uv sync --active
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --active
+
 RUN chmod +x /app/bootstrap.sh
 
 # Keep the original postgres entrypoint

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
-ARG POSTGRES_VERSION
+# Declare the build argument before FROM
+ARG POSTGRES_VERSION=16
+
+# Use the build argument in FROM
 FROM postgres:${POSTGRES_VERSION}
+
+# Install build dependencies for psycopg2
+RUN apt-get update && apt-get install -y \
+    gcc \
+    python3-dev \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
 
 # Copy uv from the official image
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/

--- a/README.md
+++ b/README.md
@@ -73,6 +73,18 @@ docker build --build-arg POSTGRES_VERSION=16 -t autopg .
 docker run -e POSTGRES_USER=test_user -e POSTGRES_PASSWORD=test_password autopg
 ```
 
+## Unit Test
+
+We have unit tests for the logic and integration tests for the docker image.
+
+```bash
+uv run pytest -vvv
+```
+
+```bash
+uv run pytest -vvv -m "integration"
+```
+
 ## Limitations
 
 - Right now we write the optimization logic in Python so our postgres container relies on having a python interpreter installed. This adds a bit to space overhead and is potentially a security risk. We'd rather bundle a compiled binary that serves the same purpose.

--- a/autopg/__tests__/test_docker.py
+++ b/autopg/__tests__/test_docker.py
@@ -1,0 +1,104 @@
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Generator
+
+import psycopg2
+import pytest
+
+from autopg.postgres import write_postgresql_conf
+
+
+@pytest.fixture
+def temp_workspace() -> Generator[Path, None, None]:
+    """Create a temporary workspace for Docker tests"""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        workspace = Path(temp_dir) / "workspace"
+        # Copy current workspace to temp directory
+        shutil.copytree(os.getcwd(), workspace, dirs_exist_ok=True)
+        yield workspace
+
+
+@pytest.mark.parametrize("postgres_version", ["16", "17"])
+def test_docker_max_connections(temp_workspace: Path, postgres_version: str) -> None:
+    """
+    Test that Docker image correctly applies PostgreSQL configuration changes.
+    Specifically tests max_connections parameter.
+
+    :param temp_workspace: Temporary directory containing a copy of the workspace
+    :param postgres_version: Version of PostgreSQL to test with
+
+    """
+    # Write a custom PostgreSQL configuration
+    postgres_dir = temp_workspace / "postgresql"
+    postgres_dir.mkdir(exist_ok=True)
+    write_postgresql_conf({"max_connections": "45"}, str(postgres_dir))
+
+    # Build the Docker image
+    test_tag = f"autopg:test-{postgres_version}"
+    subprocess.run(
+        [
+            "docker",
+            "build",
+            "--build-arg",
+            f"POSTGRES_VERSION={postgres_version}",
+            "-t",
+            test_tag,
+            ".",
+        ],
+        cwd=temp_workspace,
+        check=True,
+    )
+
+    # Start the container with credentials
+    container_id = (
+        subprocess.check_output(
+            [
+                "docker",
+                "run",
+                "-d",
+                "-p",
+                "5432:5432",
+                "-e",
+                "POSTGRES_USER=test_user",
+                "-e",
+                "POSTGRES_PASSWORD=test_password",
+                test_tag,
+            ],
+            cwd=temp_workspace,
+        )
+        .decode()
+        .strip()
+    )
+
+    try:
+        # Wait for PostgreSQL to be ready
+        subprocess.run(
+            ["docker", "exec", container_id, "pg_isready", "-t", "30"],
+            check=True,
+        )
+
+        # Connect and verify max_connections
+        conn = psycopg2.connect(
+            host="localhost",
+            port=5432,
+            user="test_user",
+            password="test_password",
+            database="test_user",  # PostgreSQL creates a database with the same name as the user by default
+        )
+        try:
+            with conn.cursor() as cur:
+                cur.execute("SHOW max_connections")
+                result = cur.fetchone()
+                if result is None:
+                    raise AssertionError("No result returned from max_connections query")
+                assert result[0] == "45"  # PostgreSQL returns this as a string
+        finally:
+            conn.close()
+
+    finally:
+        # Clean up the container
+        subprocess.run(["docker", "stop", container_id], check=True)
+        subprocess.run(["docker", "rm", container_id], check=True)

--- a/autopg/cli.py
+++ b/autopg/cli.py
@@ -207,6 +207,13 @@ def build_config(pg_path: str) -> None:
     if io_concurrency is not None:
         new_config["effective_io_concurrency"] = io_concurrency
 
+    # Add in the docker specific settings
+    new_config["listen_addresses"] = "*"
+    new_config["dynamic_shared_memory_type"] = "posix"
+    new_config["log_timezone"] = "Etc/UTC"
+    new_config["datestyle"] = "iso, mdy"
+    new_config["timezone"] = "Etc/UTC"
+
     # Merge configurations, preferring existing values
     existing_config = read_postgresql_conf(pg_path)
     final_config = format_postgres_values({**new_config, **existing_config})

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,4 +6,4 @@ autopg build-config --pg-path /etc/postgresql
 
 echo "Booting PostgreSQL..."
 
-exec docker-entrypoint.sh postgres
+exec docker-entrypoint.sh postgres -c config_file=/etc/postgresql/postgresql.conf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "pytest>=8.3.4",
     "ruff>=0.3.0",
     "pyright>=1.1.350",
+    "psycopg2>=2.9.10",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
     "pytest>=8.3.4",
     "ruff>=0.3.0",
     "pyright>=1.1.350",
-    "psycopg2>=2.9.10",
+    "psycopg>=3.2.5",
 ]
 
 [build-system]
@@ -38,3 +38,9 @@ ignore = ["E501"]
 [tool.pyright]
 pythonVersion = "3.12"
 typeCheckingMode = "strict"
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: marks tests that require external services (deselect with '-m \"not integration\"')",
+]
+addopts = "-m 'not integration'"

--- a/uv.lock
+++ b/uv.lock
@@ -24,6 +24,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "psycopg2" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "ruff" },
@@ -40,6 +41,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "psycopg2", specifier = ">=2.9.10" },
     { name = "pyright", specifier = ">=1.1.350" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "ruff", specifier = ">=0.3.0" },
@@ -136,6 +138,17 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/47/da/99f4345d4ddf2845cb5b5bd0d93d554e84542d116934fde07a0c50bd4e9f/psutil-6.1.1-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:33431e84fee02bc84ea36d9e2c4a6d395d479c9dd9bba2376c1f6ee8f3a4e0b3", size = 289017 },
     { url = "https://files.pythonhosted.org/packages/38/53/bd755c2896f4461fd4f36fa6a6dcb66a88a9e4b9fd4e5b66a77cf9d4a584/psutil-6.1.1-cp37-abi3-win32.whl", hash = "sha256:eaa912e0b11848c4d9279a93d7e2783df352b082f40111e078388701fd479e53", size = 250602 },
     { url = "https://files.pythonhosted.org/packages/7b/d7/7831438e6c3ebbfa6e01a927127a6cb42ad3ab844247f3c5b96bea25d73d/psutil-6.1.1-cp37-abi3-win_amd64.whl", hash = "sha256:f35cfccb065fff93529d2afb4a2e89e363fe63ca1e4a5da22b603a85833c2649", size = 254444 },
+]
+
+[[package]]
+name = "psycopg2"
+version = "2.9.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/51/2007ea29e605957a17ac6357115d0c1a1b60c8c984951c19419b3474cdfd/psycopg2-2.9.10.tar.gz", hash = "sha256:12ec0b40b0273f95296233e8750441339298e6a572f7039da5b260e3c8b60e11", size = 385672 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/16/4623fad6076448df21c1a870c93a9774ad8a7b4dd1660223b59082dd8fec/psycopg2-2.9.10-cp312-cp312-win32.whl", hash = "sha256:65a63d7ab0e067e2cdb3cf266de39663203d38d6a8ed97f5ca0cb315c73fe067", size = 1025113 },
+    { url = "https://files.pythonhosted.org/packages/66/de/baed128ae0fc07460d9399d82e631ea31a1f171c0c4ae18f9808ac6759e3/psycopg2-2.9.10-cp312-cp312-win_amd64.whl", hash = "sha256:4a579d6243da40a7b3182e0430493dbd55950c493d8c68f4eec0b302f6bbf20e", size = 1163951 },
+    { url = "https://files.pythonhosted.org/packages/ae/49/a6cfc94a9c483b1fa401fbcb23aca7892f60c7269c5ffa2ac408364f80dc/psycopg2-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:91fd603a2155da8d0cfcdbf8ab24a2d54bca72795b90d2a3ed2b6da8d979dee2", size = 2569060 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -24,7 +24,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "psycopg2" },
+    { name = "psycopg" },
     { name = "pyright" },
     { name = "pytest" },
     { name = "ruff" },
@@ -41,7 +41,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "psycopg2", specifier = ">=2.9.10" },
+    { name = "psycopg", specifier = ">=3.2.5" },
     { name = "pyright", specifier = ">=1.1.350" },
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "ruff", specifier = ">=0.3.0" },
@@ -141,14 +141,16 @@ wheels = [
 ]
 
 [[package]]
-name = "psycopg2"
-version = "2.9.10"
+name = "psycopg"
+version = "3.2.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/62/51/2007ea29e605957a17ac6357115d0c1a1b60c8c984951c19419b3474cdfd/psycopg2-2.9.10.tar.gz", hash = "sha256:12ec0b40b0273f95296233e8750441339298e6a572f7039da5b260e3c8b60e11", size = 385672 }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/cf/dc1a4d45e3c6222fe272a245c5cea9a969a7157639da606ac7f2ab5de3a1/psycopg-3.2.5.tar.gz", hash = "sha256:f5f750611c67cb200e85b408882f29265c66d1de7f813add4f8125978bfd70e8", size = 156158 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/16/4623fad6076448df21c1a870c93a9774ad8a7b4dd1660223b59082dd8fec/psycopg2-2.9.10-cp312-cp312-win32.whl", hash = "sha256:65a63d7ab0e067e2cdb3cf266de39663203d38d6a8ed97f5ca0cb315c73fe067", size = 1025113 },
-    { url = "https://files.pythonhosted.org/packages/66/de/baed128ae0fc07460d9399d82e631ea31a1f171c0c4ae18f9808ac6759e3/psycopg2-2.9.10-cp312-cp312-win_amd64.whl", hash = "sha256:4a579d6243da40a7b3182e0430493dbd55950c493d8c68f4eec0b302f6bbf20e", size = 1163951 },
-    { url = "https://files.pythonhosted.org/packages/ae/49/a6cfc94a9c483b1fa401fbcb23aca7892f60c7269c5ffa2ac408364f80dc/psycopg2-2.9.10-cp313-cp313-win_amd64.whl", hash = "sha256:91fd603a2155da8d0cfcdbf8ab24a2d54bca72795b90d2a3ed2b6da8d979dee2", size = 2569060 },
+    { url = "https://files.pythonhosted.org/packages/18/f3/14a1370b1449ca875d5e353ef02cb9db6b70bd46ec361c236176837c0be1/psycopg-3.2.5-py3-none-any.whl", hash = "sha256:b782130983e5b3de30b4c529623d3687033b4dafa05bb661fc6bf45837ca5879", size = 198749 },
 ]
 
 [[package]]
@@ -308,4 +310,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/0f/fa4723f22942480be4ca9527bbde8d43f6c3f2fe8412f00e7f5f6746bc8b/tzdata-2025.1.tar.gz", hash = "sha256:24894909e88cdb28bd1636c6887801df64cb485bd593f2fd83ef29075a81d694", size = 194950 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/dd/84f10e23edd882c6f968c21c2434fe67bd4a528967067515feca9e611e5e/tzdata-2025.1-py2.py3-none-any.whl", hash = "sha256:7e127113816800496f027041c570f50bcd464a020098a3b6b199517772303639", size = 346762 },
 ]


### PR DESCRIPTION
Different versions of postgres expect different config paths, which we didn't previously incorporate into our bootstrapping script. This PR specifies an explicit config path that will work across versions and adds integration tests to verify this behavior during an actual docker run.