### PR TITLE
Expand postgres versions for integration tests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,7 @@ jobs:
     
     strategy:
       matrix:
-        postgres-version: ['10', '11', '12', '13', '14', '15', '16', '17']
+        postgres-version: ['14', '15', '16', '17']
         
     steps:
       - name: Checkout repository

--- a/autopg/__tests__/test_docker.py
+++ b/autopg/__tests__/test_docker.py
@@ -128,7 +128,7 @@ def cleanup_container(container_id: str) -> None:
 
 
 @pytest.mark.integration
-@pytest.mark.parametrize("postgres_version", ["16", "17"])
+@pytest.mark.parametrize("postgres_version", ["14", "15", "16", "17"])
 def test_docker_max_connections(temp_workspace: Path, postgres_version: str) -> None:
     """
     Test that Docker image correctly applies PostgreSQL configuration changes.


### PR DESCRIPTION
- Improve the integration tests to cover the full version range of postgres containers that we build
- Remove building for postgres10-13 since debian has reached the end of its support and deps can't be easily updated