### PR TITLE
Add autopgpool

### DIFF
--- a/.github/workflows/docker-pool.yml
+++ b/.github/workflows/docker-pool.yml
@@ -1,0 +1,64 @@
+name: Docker PgBouncer Images
+
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+    types: [labeled, synchronize]
+  # Allow manual trigger for testing
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-pool
+
+jobs:
+  build-and-push:
+    # Skip if PR without "Full Build" label
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'Full Build'))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to the Container registry
+        # Only login for actual deployments
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            # Tag with release tag (e.g. v1.0.0)
+            type=raw,value=${{ github.ref_name }}
+            # Tag with latest
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./autopgpool
+          # Only push for tag events
+          push: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max 

--- a/.github/workflows/test-pool.yml
+++ b/.github/workflows/test-pool.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Run tests
       run: |
         cd autopgpool
-        uv run pytest -vvv
+        uv run pytest -vvv autopgpool
 
   integration-test:
     runs-on: ubuntu-latest
@@ -63,4 +63,4 @@ jobs:
     - name: Run integration tests
       run: |
         cd autopgpool
-        uv run pytest -vvv -m "integration" 
+        uv run pytest -vvv -m "integration" autopgpool

--- a/.github/workflows/test-pool.yml
+++ b/.github/workflows/test-pool.yml
@@ -1,0 +1,66 @@
+name: Test PgBouncer
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        
+    - name: Install uv
+      run: |
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        
+    - name: Install dependencies
+      run: |
+        cd autopgpool
+        uv sync
+        
+    - name: Run tests
+      run: |
+        cd autopgpool
+        uv run pytest -vvv
+
+  integration-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11"]
+
+    steps:
+    - uses: actions/checkout@v4
+    
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+        
+    - name: Install uv
+      run: |
+        curl -LsSf https://astral.sh/uv/install.sh | sh
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
+        
+    - name: Install dependencies
+      run: |
+        cd autopgpool
+        uv sync
+        
+    - name: Run integration tests
+      run: |
+        cd autopgpool
+        uv run pytest -vvv -m "integration" 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
         
     - name: Run tests
       run: |
-        uv run pytest -vvv
+        uv run pytest -vvv autopg
 
   integration-test:
     runs-on: ubuntu-latest
@@ -59,4 +59,4 @@ jobs:
         
     - name: Run integration tests
       run: |
-        uv run pytest -vvv -m "integration"
+        uv run pytest -vvv -m "integration" autopg

--- a/autopgpool/Dockerfile
+++ b/autopgpool/Dockerfile
@@ -13,7 +13,7 @@ RUN cd /pgbouncer && ./configure --prefix=/usr && make
 
 FROM alpine:3.21
 
-RUN apk add --no-cache busybox libevent postgresql-client && \
+RUN apk add --no-cache python3 py3-pip busybox libevent postgresql-client && \
   mkdir -p /etc/pgbouncer /var/log/pgbouncer /var/run/pgbouncer && \
   chown -R postgres /var/log/pgbouncer /var/run/pgbouncer /etc/pgbouncer
 

--- a/autopgpool/Dockerfile
+++ b/autopgpool/Dockerfile
@@ -1,0 +1,60 @@
+FROM alpine:3.21 AS build
+ARG VERSION=1.24.1
+
+# Install build dependencies
+RUN apk add --no-cache autoconf autoconf-doc automake curl gcc git libc-dev libevent-dev libtool make openssl-dev pandoc pkgconfig
+
+# Download and extract pgbouncer
+RUN curl -sS -o /pgbouncer.tar.gz -L https://pgbouncer.github.io/downloads/files/$VERSION/pgbouncer-$VERSION.tar.gz && \
+  tar -xzf /pgbouncer.tar.gz && mv /pgbouncer-$VERSION /pgbouncer
+
+# Build pgbouncer
+RUN cd /pgbouncer && ./configure --prefix=/usr && make
+
+FROM alpine:3.21
+
+# Install Python and required dependencies
+RUN apk add --no-cache python3 py3-pip busybox libevent postgresql-client && \
+  mkdir -p /etc/pgbouncer /var/log/pgbouncer /var/run/pgbouncer && \
+  touch /etc/pgbouncer/userlist.txt && \
+  chown -R postgres /var/log/pgbouncer /var/run/pgbouncer /etc/pgbouncer
+
+# Copy pgbouncer binary and example configs
+COPY --from=build /pgbouncer/pgbouncer /usr/bin
+COPY --from=build /pgbouncer/etc/pgbouncer.ini /etc/pgbouncer/pgbouncer.ini.example
+COPY --from=build /pgbouncer/etc/userlist.txt /etc/pgbouncer/userlist.txt.example
+
+# Copy uv from the official image
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
+
+# Create a virtual environment and install Python using uv
+ENV VIRTUAL_ENV=/opt/venv
+RUN uv venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Create a working directory for the package
+WORKDIR /app
+
+# Copy the autopg package
+COPY . .
+
+# Install the package
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --active
+
+# Create bootstrap script
+RUN echo '#!/bin/bash\n\
+\n\
+echo "Running Autopg for PgBouncer..."\n\
+\n\
+autopg build-config --pg-path /etc/pgbouncer\n\
+\n\
+echo "Booting PgBouncer..."\n\
+\n\
+exec "$@"\n' > /app/bootstrap.sh && \
+chmod +x /app/bootstrap.sh
+
+EXPOSE 5432
+USER postgres
+ENTRYPOINT ["/app/bootstrap.sh"]
+CMD ["/usr/bin/pgbouncer", "/etc/pgbouncer/pgbouncer.ini"]

--- a/autopgpool/Dockerfile
+++ b/autopgpool/Dockerfile
@@ -13,16 +13,12 @@ RUN cd /pgbouncer && ./configure --prefix=/usr && make
 
 FROM alpine:3.21
 
-# Install Python and required dependencies
-RUN apk add --no-cache python3 py3-pip busybox libevent postgresql-client && \
+RUN apk add --no-cache busybox libevent postgresql-client && \
   mkdir -p /etc/pgbouncer /var/log/pgbouncer /var/run/pgbouncer && \
-  touch /etc/pgbouncer/userlist.txt && \
   chown -R postgres /var/log/pgbouncer /var/run/pgbouncer /etc/pgbouncer
 
-# Copy pgbouncer binary and example configs
+# Copy pgbouncer binary
 COPY --from=build /pgbouncer/pgbouncer /usr/bin
-COPY --from=build /pgbouncer/etc/pgbouncer.ini /etc/pgbouncer/pgbouncer.ini.example
-COPY --from=build /pgbouncer/etc/userlist.txt /etc/pgbouncer/userlist.txt.example
 
 # Copy uv from the official image
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
@@ -35,26 +31,19 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 # Create a working directory for the package
 WORKDIR /app
 
-# Copy the autopg package
+# Install dependencies using uv
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --frozen --active --no-install-project
+
 COPY . .
 
-# Install the package
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --active
 
-# Create bootstrap script
-RUN echo '#!/bin/bash\n\
-\n\
-echo "Running Autopg for PgBouncer..."\n\
-\n\
-autopg build-config --pg-path /etc/pgbouncer\n\
-\n\
-echo "Booting PgBouncer..."\n\
-\n\
-exec "$@"\n' > /app/bootstrap.sh && \
-chmod +x /app/bootstrap.sh
+RUN chmod +x /app/bootstrap.sh
 
 EXPOSE 5432
-USER postgres
 ENTRYPOINT ["/app/bootstrap.sh"]
 CMD ["/usr/bin/pgbouncer", "/etc/pgbouncer/pgbouncer.ini"]

--- a/autopgpool/README.md
+++ b/autopgpool/README.md
@@ -1,0 +1,16 @@
+# autopgpool
+
+`autopgpool` is a postgres pooler with opinionated default configurations.
+
+Unlike `autopg`, which is guaranteed to wrap standard postgres with auto-configuration useful on any device, `autopgpool` is more geared to users that are self hosting postgres and want a lightweight pooling layer out of the box.
+
+It's currently a wrapper on top of the battle hardened [pgbouncer](https://www.pgbouncer.org/), but this is an implementation detail that could change in the future.
+
+## Configuration
+
+```toml
+```
+
+### autopgpool vs vanilla pgbouncer
+
+Vanilla pgbouncer requires configuration through `pgbouncer.ini` and `userlist.txt` files that are placed on disk. This works fine for static configuration, but requires you to hard-code in any env variables (and to pre-calculate the md5 hash of your user credentials before deployment).

--- a/autopgpool/README.md
+++ b/autopgpool/README.md
@@ -6,6 +6,13 @@ Unlike `autopg`, which is guaranteed to wrap standard Postgres with auto-configu
 
 It's currently a wrapper on top of the battle hardened [pgbouncer](https://www.pgbouncer.org/), but this is an implementation detail that could change in the future.
 
+## Features
+
+- toml configurable with a single deployment file (mounted via a docker volume typically)
+- simple user based access grants to different tables
+- automatic md5 calculation of user passwords
+- environment variable insertion to let your docker container remain the source of truth for configuration variables
+
 ## Basic configuration
 
 You'll minimally need to provide definitions for the remote databases that you want to route into, and the users that you'll use to connect to the pool. We will expand any env variables you include to their current values:

--- a/autopgpool/README.md
+++ b/autopgpool/README.md
@@ -6,10 +6,24 @@ Unlike `autopg`, which is guaranteed to wrap standard postgres with auto-configu
 
 It's currently a wrapper on top of the battle hardened [pgbouncer](https://www.pgbouncer.org/), but this is an implementation detail that could change in the future.
 
-## Configuration
+## Basic configuration
+
+You'll minimally need to provide definitions for the remote databases that you want to route into, and the users that you'll use to connect to the pool. We will expand any env variables you include to their current values:
 
 ```toml
+[[users]]
+username = "app_user"
+password = "$APP_CLIENT_PASSWORD"
+
+[pools.main_db.remote]
+host = "127.0.0.1"
+port = "5056"
+database = "main_db"
+username = "main_user"
+password = "$MAIN_DB_PASSWORD"
 ```
+
+For a more complete example config, see config.example.toml.
 
 ### autopgpool vs vanilla pgbouncer
 

--- a/autopgpool/README.md
+++ b/autopgpool/README.md
@@ -1,8 +1,8 @@
 # autopgpool
 
-`autopgpool` is a postgres pooler with opinionated default configurations.
+`autopgpool` is a Postgres pooler with opinionated default configurations.
 
-Unlike `autopg`, which is guaranteed to wrap standard postgres with auto-configuration useful on any device, `autopgpool` is more geared to users that are self hosting postgres and want a lightweight pooling layer out of the box.
+Unlike `autopg`, which is guaranteed to wrap standard Postgres with auto-configuration useful on any device, `autopgpool` is more geared to users that are self hosting postgres and want a lightweight pooling layer out of the box.
 
 It's currently a wrapper on top of the battle hardened [pgbouncer](https://www.pgbouncer.org/), but this is an implementation detail that could change in the future.
 

--- a/autopgpool/autopgpool/__tests__/conftest.py
+++ b/autopgpool/autopgpool/__tests__/conftest.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def project_root() -> Path:
+    """
+    Find the project root by looking for the pyproject.toml file.
+
+    Returns:
+        pathlib.Path: Path to the project root
+    """
+    current_dir = Path(__file__).resolve().parent
+
+    while current_dir != current_dir.parent:
+        if (current_dir / "pyproject.toml").exists():
+            return current_dir
+        current_dir = current_dir.parent
+
+    raise FileNotFoundError("Could not find project root (pyproject.toml)")

--- a/autopgpool/autopgpool/__tests__/conftest.py
+++ b/autopgpool/autopgpool/__tests__/conftest.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Generator
 
 import pytest
 
@@ -19,3 +21,10 @@ def project_root() -> Path:
         current_dir = current_dir.parent
 
     raise FileNotFoundError("Could not find project root (pyproject.toml)")
+
+
+@pytest.fixture
+def temp_dir() -> Generator[Path, None, None]:
+    """Fixture that provides a temporary directory as a Path object."""
+    with TemporaryDirectory() as temp_dir:
+        yield Path(temp_dir)

--- a/autopgpool/autopgpool/__tests__/test_cli.py
+++ b/autopgpool/autopgpool/__tests__/test_cli.py
@@ -45,9 +45,9 @@ def test_generate_pgbouncer_config(temp_dir: Path) -> None:
     # Verify key configuration elements are present
     assert "[pgbouncer]" in pgbouncer_ini
     assert "listen_port = 6432" in pgbouncer_ini
-    assert 'auth_type = "hba"' in pgbouncer_ini  # overridden
+    assert "auth_type = hba" in pgbouncer_ini  # overridden
     assert "auth_file = " in pgbouncer_ini
-    assert 'application_name = "pgbouncer"' in pgbouncer_ini
+    assert "application_name = pgbouncer" in pgbouncer_ini
     assert "[databases]" in pgbouncer_ini
     assert "testdb = " in pgbouncer_ini
     assert "host=localhost" in pgbouncer_ini
@@ -66,13 +66,9 @@ def test_generate_pgbouncer_config(temp_dir: Path) -> None:
     # Check HBA entries for testuser
     assert "local\ttestdb\ttestuser\t\tmd5" in hba_content
     assert "host\ttestdb\ttestuser\t0.0.0.0/0\tmd5" in hba_content
-    assert "host\ttestdb\ttestuser\t::0/0\tmd5" in hba_content
-    assert "host\tall\ttestuser\t!0.0.0.0/0\t!md5" in hba_content
-    assert "host\tall\ttestuser\t!::0/0\t!md5" in hba_content
+    assert "host\ttestdb\ttestuser\t::/0\tmd5" in hba_content
 
     # Check HBA entries for admin
     assert "local\ttestdb\tadmin\t\tmd5" in hba_content
     assert "host\ttestdb\tadmin\t0.0.0.0/0\tmd5" in hba_content
-    assert "host\ttestdb\tadmin\t::0/0\tmd5" in hba_content
-    assert "host\tall\tadmin\t!0.0.0.0/0\t!md5" in hba_content
-    assert "host\tall\tadmin\t!::0/0\t!md5" in hba_content
+    assert "host\ttestdb\tadmin\t::/0\tmd5" in hba_content

--- a/autopgpool/autopgpool/__tests__/test_cli.py
+++ b/autopgpool/autopgpool/__tests__/test_cli.py
@@ -1,0 +1,67 @@
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from autopgpool.cli import generate_pgbouncer_config
+from autopgpool.config import MainConfig, PgbouncerConfig, Pool, User
+
+
+def test_generate_pgbouncer_config() -> None:
+    """Test that pgbouncer config files are generated correctly."""
+    # Create a test config
+    config = MainConfig(
+        users=[
+            User(username="testuser", password="testpass", grants=["testdb"]),
+            User(username="admin", password="adminpass", grants=["testdb"]),
+        ],
+        pools={
+            "testdb": Pool(
+                remote=Pool.RemoteDatabase(
+                    host="localhost",
+                    port=5432,
+                    database="testdb",
+                    username="pguser",
+                    password="pgpass",
+                ),
+                pool_mode="transaction",
+            )
+        },
+        pgbouncer=PgbouncerConfig(
+            listen_port=6432,
+            auth_type="md5",
+            admin_users=["admin"],
+            passthrough_kwargs={"application_name": "pgbouncer"},
+        ),
+    )
+
+    # Create a temporary directory for the output
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Generate the config files
+        generate_pgbouncer_config(config, temp_dir)
+
+        # Check that the files were created
+        assert os.path.exists(os.path.join(temp_dir, "pgbouncer.ini"))
+        assert os.path.exists(os.path.join(temp_dir, "userlist.txt"))
+
+        # Check the content of the pgbouncer.ini file
+        with open(os.path.join(temp_dir, "pgbouncer.ini"), "r") as f:
+            pgbouncer_ini = f.read()
+            # Verify key configuration elements are present
+            assert "[pgbouncer]" in pgbouncer_ini
+            assert "listen_port = 6432" in pgbouncer_ini
+            assert "auth_type = \"md5\"" in pgbouncer_ini
+            assert "application_name = \"pgbouncer\"" in pgbouncer_ini
+            assert "[databases]" in pgbouncer_ini
+            assert "testdb = " in pgbouncer_ini
+            assert "host=localhost" in pgbouncer_ini
+            assert "port=5432" in pgbouncer_ini
+
+        # Check the content of the userlist.txt file
+        with open(os.path.join(temp_dir, "userlist.txt"), "r") as f:
+            userlist = f.read()
+            # MD5 passwords are hashed, so we can't check exact values
+            assert "\"testuser\"" in userlist
+            assert "\"admin\"" in userlist

--- a/autopgpool/autopgpool/__tests__/test_cli.py
+++ b/autopgpool/autopgpool/__tests__/test_cli.py
@@ -1,15 +1,10 @@
-import os
-import tempfile
 from pathlib import Path
-from unittest.mock import patch
-
-import pytest
 
 from autopgpool.cli import generate_pgbouncer_config
 from autopgpool.config import MainConfig, PgbouncerConfig, Pool, User
 
 
-def test_generate_pgbouncer_config() -> None:
+def test_generate_pgbouncer_config(temp_dir: Path) -> None:
     """Test that pgbouncer config files are generated correctly."""
     # Create a test config
     config = MainConfig(
@@ -37,31 +32,47 @@ def test_generate_pgbouncer_config() -> None:
         ),
     )
 
-    # Create a temporary directory for the output
-    with tempfile.TemporaryDirectory() as temp_dir:
-        # Generate the config files
-        generate_pgbouncer_config(config, temp_dir)
+    # Generate the config files
+    generate_pgbouncer_config(config, str(temp_dir))
 
-        # Check that the files were created
-        assert os.path.exists(os.path.join(temp_dir, "pgbouncer.ini"))
-        assert os.path.exists(os.path.join(temp_dir, "userlist.txt"))
+    # Check that the files were created
+    assert (temp_dir / "pgbouncer.ini").exists()
+    assert (temp_dir / "userlist.txt").exists()
+    assert (temp_dir / "pgbouncer_hba.conf").exists()
 
-        # Check the content of the pgbouncer.ini file
-        with open(os.path.join(temp_dir, "pgbouncer.ini"), "r") as f:
-            pgbouncer_ini = f.read()
-            # Verify key configuration elements are present
-            assert "[pgbouncer]" in pgbouncer_ini
-            assert "listen_port = 6432" in pgbouncer_ini
-            assert "auth_type = \"md5\"" in pgbouncer_ini
-            assert "application_name = \"pgbouncer\"" in pgbouncer_ini
-            assert "[databases]" in pgbouncer_ini
-            assert "testdb = " in pgbouncer_ini
-            assert "host=localhost" in pgbouncer_ini
-            assert "port=5432" in pgbouncer_ini
+    # Check the content of the pgbouncer.ini file
+    pgbouncer_ini = (temp_dir / "pgbouncer.ini").read_text()
+    # Verify key configuration elements are present
+    assert "[pgbouncer]" in pgbouncer_ini
+    assert "listen_port = 6432" in pgbouncer_ini
+    assert 'auth_type = "hba"' in pgbouncer_ini  # overridden
+    assert "auth_file = " in pgbouncer_ini
+    assert 'application_name = "pgbouncer"' in pgbouncer_ini
+    assert "[databases]" in pgbouncer_ini
+    assert "testdb = " in pgbouncer_ini
+    assert "host=localhost" in pgbouncer_ini
+    assert "port=5432" in pgbouncer_ini
 
-        # Check the content of the userlist.txt file
-        with open(os.path.join(temp_dir, "userlist.txt"), "r") as f:
-            userlist = f.read()
-            # MD5 passwords are hashed, so we can't check exact values
-            assert "\"testuser\"" in userlist
-            assert "\"admin\"" in userlist
+    # Check the content of the userlist.txt file
+    userlist = (temp_dir / "userlist.txt").read_text()
+    # MD5 passwords are hashed, so we can't check exact values
+    assert '"testuser"' in userlist
+    assert '"admin"' in userlist
+
+    # Check the content of the HBA file
+    hba_content = (temp_dir / "pgbouncer_hba.conf").read_text()
+    assert "# TYPE\tDATABASE\tUSER\tADDRESS\tMETHOD" in hba_content
+
+    # Check HBA entries for testuser
+    assert "local\ttestdb\ttestuser\t\tmd5" in hba_content
+    assert "host\ttestdb\ttestuser\t0.0.0.0/0\tmd5" in hba_content
+    assert "host\ttestdb\ttestuser\t::0/0\tmd5" in hba_content
+    assert "host\tall\ttestuser\t!0.0.0.0/0\t!md5" in hba_content
+    assert "host\tall\ttestuser\t!::0/0\t!md5" in hba_content
+
+    # Check HBA entries for admin
+    assert "local\ttestdb\tadmin\t\tmd5" in hba_content
+    assert "host\ttestdb\tadmin\t0.0.0.0/0\tmd5" in hba_content
+    assert "host\ttestdb\tadmin\t::0/0\tmd5" in hba_content
+    assert "host\tall\tadmin\t!0.0.0.0/0\t!md5" in hba_content
+    assert "host\tall\tadmin\t!::0/0\t!md5" in hba_content

--- a/autopgpool/autopgpool/__tests__/test_config.py
+++ b/autopgpool/autopgpool/__tests__/test_config.py
@@ -1,0 +1,22 @@
+import tomllib
+from pathlib import Path
+from typing import Any
+
+from autopgpool.config import MainConfig
+
+
+def test_example_config_loads_correctly(project_root: Path) -> None:
+    """
+    Test that the example config file can be loaded correctly into the MainConfig model.
+    """
+    # Find the project root and the example config file
+    example_config_path = project_root / "config.example.toml"
+
+    assert example_config_path.exists(), f"Example config file not found at {example_config_path}"
+
+    # Load the TOML file
+    with open(example_config_path, "rb") as f:
+        config_data: dict[str, Any] = tomllib.load(f)
+
+    # Parse the config data into the MainConfig model
+    MainConfig.model_validate(config_data)

--- a/autopgpool/autopgpool/__tests__/test_docker.py
+++ b/autopgpool/autopgpool/__tests__/test_docker.py
@@ -1,0 +1,314 @@
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from time import sleep, time
+from typing import Generator
+
+import psycopg
+import pytest
+from rich.console import Console
+
+console = Console()
+
+
+@pytest.fixture
+def temp_workspace() -> Generator[Path, None, None]:
+    """Create a temporary workspace for Docker tests"""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        workspace = Path(temp_dir) / "workspace"
+        # Copy current workspace to temp directory
+        shutil.copytree(os.getcwd(), workspace, dirs_exist_ok=True)
+        yield workspace
+
+
+def build_autopgpool_docker_image(temp_workspace: Path) -> str:
+    """
+    Build the AutoPGPool Docker image for testing.
+
+    :param temp_workspace: Temporary directory containing a copy of the workspace
+    :return: Docker image tag
+    """
+    test_tag = "autopgpool:test"
+    subprocess.run(
+        [
+            "docker",
+            "build",
+            "-t",
+            test_tag,
+            ".",
+        ],
+        cwd=temp_workspace,
+        check=True,
+    )
+    return test_tag
+
+
+def start_postgres_container(temp_workspace: Path) -> tuple[str, int]:
+    """
+    Start a PostgreSQL container for testing.
+
+    :param temp_workspace: Temporary directory containing a copy of the workspace
+    :return: Container ID and mapped port
+    """
+    # Use a random port on the host to avoid conflicts
+    postgres_port = 5433
+
+    container_id = (
+        subprocess.check_output(
+            [
+                "docker",
+                "run",
+                "-d",
+                "-p",
+                f"{postgres_port}:5432",
+                "-e",
+                "POSTGRES_USER=test_user",
+                "-e",
+                "POSTGRES_PASSWORD=test_password",
+                "-e",
+                "POSTGRES_DB=test_db",
+                "postgres:15",
+            ],
+            cwd=temp_workspace,
+        )
+        .decode()
+        .strip()
+    )
+
+    return container_id, postgres_port
+
+
+def wait_for_postgres(container_id: str, timeout_seconds: int = 30) -> None:
+    """
+    Wait for PostgreSQL to be ready with a timeout.
+
+    :param container_id: Docker container ID
+    :param timeout_seconds: Maximum time to wait in seconds
+    """
+    start_time = time()
+    while True:
+        if time() - start_time > timeout_seconds:
+            raise TimeoutError(f"PostgreSQL not ready after {timeout_seconds} seconds")
+
+        try:
+            subprocess.run(
+                ["docker", "exec", container_id, "pg_isready", "-t", "5"],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            console.print("PostgreSQL is ready")
+            break
+        except subprocess.CalledProcessError:
+            sleep(1)
+
+    # Give time to fully boot and be reachable
+    sleep(2)
+
+
+def create_test_config(temp_workspace: Path, postgres_host: str, postgres_port: int) -> Path:
+    """
+    Create a test configuration file for autopgpool.
+
+    :param temp_workspace: Temporary directory containing a copy of the workspace
+    :param postgres_host: Hostname of the PostgreSQL container
+    :param postgres_port: Port of the PostgreSQL container
+    :return: Path to the configuration file
+    """
+    config_content = f"""
+# AutoPGPool Test Configuration
+
+# User definitions
+[[users]]
+username = "test_user"
+password = "test_password"
+grants = ["test_db"]
+
+# Database definitions
+[pools.test_db]
+pool_mode = "transaction"
+
+[pools.test_db.remote]
+host = "{postgres_host}"
+port = {postgres_port}
+database = "test_db"
+username = "test_user"
+password = "test_password"
+
+# PGBouncer configuration
+[pgbouncer]
+listen_addr = "0.0.0.0"
+listen_port = 6432
+auth_type = "md5"
+pool_mode = "transaction"
+max_client_conn = 100
+default_pool_size = 20
+ignore_startup_parameters = ["extra_float_digits"]
+"""
+
+    config_path = temp_workspace / "test_config.toml"
+    with open(config_path, "w") as f:
+        f.write(config_content)
+
+    return config_path
+
+
+def start_autopgpool_container(
+    temp_workspace: Path,
+    image_tag: str,
+    config_path: Path,
+) -> tuple[str, int]:
+    """
+    Start an autopgpool container for testing.
+
+    :param temp_workspace: Temporary directory containing a copy of the workspace
+    :param image_tag: Docker image tag to run
+    :param config_path: Path to the configuration file
+    :return: Container ID and mapped port
+    """
+    # Use a random port to avoid conflicts
+    pgbouncer_port = 6432
+
+    container_id = (
+        subprocess.check_output(
+            [
+                "docker",
+                "run",
+                "-d",
+                "-p",
+                f"{pgbouncer_port}:6432",
+                "-v",
+                f"{config_path}:/etc/autopgpool/autopgpool.toml",
+                image_tag,
+            ],
+            cwd=temp_workspace,
+        )
+        .decode()
+        .strip()
+    )
+
+    return container_id, pgbouncer_port
+
+
+def wait_for_pgbouncer(container_id: str, timeout_seconds: int = 30) -> None:
+    """
+    Wait for PgBouncer to be ready with a timeout.
+
+    :param container_id: Docker container ID
+    :param timeout_seconds: Maximum time to wait in seconds
+    """
+    start_time = time()
+
+    # Wait for pgbouncer to start
+    while True:
+        if time() - start_time > timeout_seconds:
+            raise TimeoutError(f"PgBouncer not ready after {timeout_seconds} seconds")
+
+        try:
+            # Check if pgbouncer process is running
+            result = subprocess.run(
+                ["docker", "exec", container_id, "ps", "aux"],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            if "pgbouncer" in result.stdout and "/usr/bin/pgbouncer" in result.stdout:
+                console.print("PgBouncer is running")
+                break
+        except subprocess.CalledProcessError:
+            pass
+
+        sleep(1)
+
+    # Give pgbouncer time to initialize
+    sleep(5)
+
+
+def cleanup_container(container_id: str) -> None:
+    """
+    Stop and remove a Docker container.
+
+    :param container_id: Docker container ID
+    """
+    subprocess.run(["docker", "stop", container_id], check=True)
+    subprocess.run(["docker", "rm", container_id], check=True)
+
+
+@pytest.mark.integration
+def test_autopgpool_connection(temp_workspace: Path) -> None:
+    """
+    Test that AutoPGPool correctly routes connections to PostgreSQL.
+
+    This test:
+    1. Starts a PostgreSQL container
+    2. Builds and starts the AutoPGPool container
+    3. Verifies that connections can be made through the pool
+
+    :param temp_workspace: Temporary directory containing a copy of the workspace
+    """
+    postgres_container_id = None
+    pgbouncer_container_id = None
+
+    try:
+        # Start PostgreSQL container
+        postgres_container_id, postgres_port = start_postgres_container(temp_workspace)
+        wait_for_postgres(postgres_container_id)
+
+        # Create test configuration
+        config_path = create_test_config(temp_workspace, "host.docker.internal", postgres_port)
+
+        # Build and start AutoPGPool container
+        autopgpool_tag = build_autopgpool_docker_image(temp_workspace)
+        pgbouncer_container_id, pgbouncer_port = start_autopgpool_container(
+            temp_workspace,
+            autopgpool_tag,
+            config_path,
+        )
+        wait_for_pgbouncer(pgbouncer_container_id)
+
+        # Verify connection through pgbouncer
+        conn = psycopg.connect(
+            host="localhost",
+            port=pgbouncer_port,
+            user="test_user",
+            password="test_password",
+            dbname="test_db",
+        )
+
+        try:
+            with conn.cursor() as cur:
+                # Simple query to verify connection
+                cur.execute("SELECT 1 AS test")
+                result = cur.fetchone()
+                assert result is not None
+                assert result[0] == 1
+
+                # Verify connection is through pgbouncer by checking application_name
+                cur.execute("SHOW application_name")
+                result = cur.fetchone()
+                assert result is not None
+                assert "pgbouncer" in result[0].lower()
+        finally:
+            conn.close()
+
+    except Exception as e:
+        console.print(f"Error: {e}")
+
+        # Print logs from containers
+        if pgbouncer_container_id:
+            console.print("PgBouncer logs:")
+            subprocess.run(["docker", "logs", pgbouncer_container_id], check=True)
+
+        if postgres_container_id:
+            console.print("PostgreSQL logs:")
+            subprocess.run(["docker", "logs", postgres_container_id], check=True)
+
+        raise e
+    finally:
+        # Clean up containers
+        if pgbouncer_container_id:
+            cleanup_container(pgbouncer_container_id)
+        if postgres_container_id:
+            cleanup_container(postgres_container_id)

--- a/autopgpool/autopgpool/__tests__/test_env.py
+++ b/autopgpool/autopgpool/__tests__/test_env.py
@@ -1,0 +1,78 @@
+import os
+
+import pytest
+from pydantic import BaseModel
+
+from autopgpool.env import swap_env
+
+
+def test_swap_env_with_string() -> None:
+    # Set environment variables for testing
+    os.environ["TEST_VAR"] = "test_value"
+
+    # Test with a string that starts with $
+    assert swap_env("$TEST_VAR") == "test_value"
+
+    # Test with a regular string
+    assert swap_env("regular_string") == "regular_string"
+
+
+def test_swap_env_with_dict() -> None:
+    os.environ["TEST_VAR"] = "test_value"
+    os.environ["ANOTHER_VAR"] = "another_value"
+
+    test_dict = {"key1": "$TEST_VAR", "key2": "regular_value", "key3": "$ANOTHER_VAR"}
+    expected = {"key1": "test_value", "key2": "regular_value", "key3": "another_value"}
+
+    assert swap_env(test_dict) == expected
+
+
+def test_swap_env_with_list() -> None:
+    os.environ["TEST_VAR"] = "test_value"
+
+    test_list = ["$TEST_VAR", "regular_value", 123]
+    expected = ["test_value", "regular_value", 123]
+
+    assert swap_env(test_list) == expected
+
+
+def test_swap_env_with_nested_structures() -> None:
+    os.environ["TEST_VAR"] = "test_value"
+
+    test_nested = {
+        "key1": "$TEST_VAR",
+        "key2": ["regular_value", "$TEST_VAR"],
+        "key3": {"nested_key": "$TEST_VAR"},
+    }
+
+    expected = {
+        "key1": "test_value",
+        "key2": ["regular_value", "test_value"],
+        "key3": {"nested_key": "test_value"},
+    }
+
+    assert swap_env(test_nested) == expected
+
+
+def test_swap_env_missing_env_var() -> None:
+    # Ensure the environment variable doesn't exist
+    if "NONEXISTENT_VAR" in os.environ:
+        del os.environ["NONEXISTENT_VAR"]
+
+    with pytest.raises(EnvironmentError):
+        swap_env("$NONEXISTENT_VAR")
+
+
+def test_swap_env_pydantic_parse_int():
+    """
+    Verify that we can parse ints from string-based env vars.
+    This mirrors the behavior that we'll be doing when reading the config file.
+
+    """
+
+    class DemoModel(BaseModel):
+        test_int: int
+
+    os.environ["TEST_INT"] = "123"
+
+    assert DemoModel.model_validate(swap_env({"test_int": "$TEST_INT"})) == DemoModel(test_int=123)

--- a/autopgpool/autopgpool/__tests__/test_ini_writer.py
+++ b/autopgpool/autopgpool/__tests__/test_ini_writer.py
@@ -1,0 +1,178 @@
+import os
+import tempfile
+import textwrap
+from typing import Any, List
+
+import pytest
+
+from autopgpool.ini_writer import (
+    User,
+    format_ini_value,
+    write_ini_file,
+    write_userlist_file,
+)
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (True, "1"),
+        (False, "0"),
+        (123, "123"),
+        (45.67, "45.67"),
+        ("hello", '"hello"'),
+        ('hello"world', '"hello"world"'),  # String with quotes
+        (["a", "b", "c"], '"a", "b", "c"'),
+        ([1, 2, 3], "1, 2, 3"),
+        ([True, False], "1, 0"),
+        (None, ""),
+        ([None, "test"], ", \"test\""),
+        ({"key": "value"}, "{'key': 'value'}"),  # Default str() for unsupported types
+    ],
+)
+def test_format_ini_value(value: Any, expected: str) -> None:
+    """Test the format_ini_value function with various input types."""
+    assert format_ini_value(value) == expected
+
+
+def test_write_ini_file() -> None:
+    """Test writing a configuration to an INI file."""
+    config: dict[str, dict[str, Any]] = {
+        "section1": {
+            "key1": "value1",
+            "key2": 123,
+            "key3": True,
+            "key4": None,  # Should be skipped
+        },
+        "section2": {
+            "list_key": ["a", "b", "c"],
+            "bool_key": False,
+        },
+    }
+    
+    section_comments: dict[str, str] = {
+        "section1": "This is section 1",
+        # No comment for section2
+    }
+    
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        filepath = temp_file.name
+        
+    try:
+        write_ini_file(config, filepath, section_comments)
+        
+        with open(filepath, "r") as f:
+            content = f.read()
+        
+        # Verify the content
+        expected_content = textwrap.dedent("""\
+            # This is section 1
+            [section1]
+            key1 = "value1"
+            key2 = 123
+            key3 = 1
+
+            [section2]
+            list_key = "a", "b", "c"
+            bool_key = 0
+
+            """)
+        assert content == expected_content
+    finally:
+        os.unlink(filepath)
+
+
+def test_write_ini_file_no_comments() -> None:
+    """Test writing a configuration to an INI file without section comments."""
+    config: dict[str, dict[str, Any]] = {
+        "section1": {
+            "key1": "value1",
+        },
+    }
+    
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        filepath = temp_file.name
+        
+    try:
+        write_ini_file(config, filepath)  # No section_comments
+        
+        with open(filepath, "r") as f:
+            content = f.read()
+        
+        expected_content = textwrap.dedent("""\
+            [section1]
+            key1 = "value1"
+
+            """)
+        assert content == expected_content
+    finally:
+        os.unlink(filepath)
+
+
+# Test only the plain auth type since we can't easily mock scram-sha-256
+# and we don't want to test actual hashing in unit tests
+def test_write_userlist_file_plain() -> None:
+    """Test writing users to a userlist file with plain auth."""
+    users = [
+        User(username="user1", password="pass1"),
+        User(username="user2", password="pass2"),
+    ]
+    
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        filepath = temp_file.name
+        
+    try:
+        write_userlist_file(users, filepath, "plain")
+        
+        with open(filepath, "r") as f:
+            content = f.read()
+        
+        expected_content = '"user1" "pass1"\n"user2" "pass2"\n'
+        assert content == expected_content
+    finally:
+        os.unlink(filepath)
+
+
+# Test with md5 auth type by mocking hashlib.md5
+def test_write_userlist_file_md5() -> None:
+    """Test writing users to a userlist file with md5 auth."""
+    users = [
+        User(username="user1", password="pass1"),
+        User(username="user2", password="pass2"),
+    ]
+    
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        filepath = temp_file.name
+        
+    try:
+        # We're not testing the actual md5 implementation, just that it's used
+        write_userlist_file(users, filepath, "md5")
+        
+        with open(filepath, "r") as f:
+            content = f.read()
+        
+        # TODO: Fill in the actual expected content later
+        # Just verify the format is correct - username in quotes followed by something in quotes
+        assert '"user1" "' in content
+        assert '"user2" "' in content
+        assert content.count('"') == 8  # 4 pairs of quotes
+        assert content.count('\n') == 2  # 2 newlines (one per user)
+    finally:
+        os.unlink(filepath)
+
+
+def test_write_userlist_file_empty() -> None:
+    """Test writing an empty list of users."""
+    users: List[User] = []
+    
+    with tempfile.NamedTemporaryFile(delete=False) as temp_file:
+        filepath = temp_file.name
+        
+    try:
+        write_userlist_file(users, filepath, "plain")
+        
+        with open(filepath, "r") as f:
+            content = f.read()
+        
+        assert content == ""
+    finally:
+        os.unlink(filepath)

--- a/autopgpool/autopgpool/__tests__/test_ini_writer.py
+++ b/autopgpool/autopgpool/__tests__/test_ini_writer.py
@@ -20,13 +20,13 @@ from autopgpool.ini_writer import (
         (False, "0"),
         (123, "123"),
         (45.67, "45.67"),
-        ("hello", '"hello"'),
-        ('hello"world', '"hello"world"'),  # String with quotes
-        (["a", "b", "c"], '"a", "b", "c"'),
+        ("hello", "hello"),
+        ('hello"world', 'hello"world'),  # String with quotes
+        (["a", "b", "c"], "a, b, c"),
         ([1, 2, 3], "1, 2, 3"),
         ([True, False], "1, 0"),
         (None, ""),
-        ([None, "test"], ', "test"'),
+        ([None, "test"], ", test"),
         ({"key": "value"}, "{'key': 'value'}"),  # Default str() for unsupported types
     ],
 )
@@ -66,12 +66,12 @@ def test_write_ini_file() -> None:
         expected_content = textwrap.dedent("""\
             # This is section 1
             [section1]
-            key1 = "value1"
+            key1 = value1
             key2 = 123
             key3 = 1
 
             [section2]
-            list_key = "a", "b", "c"
+            list_key = a, b, c
             bool_key = 0
 
             """)
@@ -95,14 +95,12 @@ def test_write_ini_file_no_comments() -> None:
 
         expected_content = textwrap.dedent("""\
             [section1]
-            key1 = "value1"
+            key1 = value1
 
             """)
         assert content == expected_content
 
 
-# Test only the plain auth type since we can't easily mock scram-sha-256
-# and we don't want to test actual hashing in unit tests
 def test_write_userlist_file_plain() -> None:
     """Test writing users to a userlist file with plain auth."""
     users = [
@@ -121,7 +119,6 @@ def test_write_userlist_file_plain() -> None:
         assert content == expected_content
 
 
-# Test with md5 auth type by mocking hashlib.md5
 def test_write_userlist_file_md5() -> None:
     """Test writing users to a userlist file with md5 auth."""
     users = [
@@ -137,12 +134,8 @@ def test_write_userlist_file_md5() -> None:
         with open(filepath, "r") as f:
             content = f.read()
 
-        # TODO: Fill in the actual expected content later
-        # Just verify the format is correct - username in quotes followed by something in quotes
-        assert '"user1" "' in content
-        assert '"user2" "' in content
-        assert content.count('"') == 8  # 4 pairs of quotes
-        assert content.count("\n") == 2  # 2 newlines (one per user)
+        assert '"user1" "md55e4eab96e8b9868ed28cc79c9ceec8b3"' in content
+        assert '"user2" "md553cc9e310bc5e01cb42fd0aeda81e27d"' in content
 
 
 def test_write_userlist_file_empty() -> None:

--- a/autopgpool/autopgpool/__tests__/test_ini_writer.py
+++ b/autopgpool/autopgpool/__tests__/test_ini_writer.py
@@ -12,6 +12,7 @@ from autopgpool.ini_writer import (
     write_userlist_file,
 )
 
+
 @pytest.mark.parametrize(
     "value,expected",
     [
@@ -25,7 +26,7 @@ from autopgpool.ini_writer import (
         ([1, 2, 3], "1, 2, 3"),
         ([True, False], "1, 0"),
         (None, ""),
-        ([None, "test"], ", \"test\""),
+        ([None, "test"], ', "test"'),
         ({"key": "value"}, "{'key': 'value'}"),  # Default str() for unsupported types
     ],
 )
@@ -48,21 +49,21 @@ def test_write_ini_file() -> None:
             "bool_key": False,
         },
     }
-    
+
     section_comments: dict[str, str] = {
         "section1": "This is section 1",
         # No comment for section2
     }
-    
+
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
         filepath = temp_file.name
-        
+
     try:
         write_ini_file(config, filepath, section_comments)
-        
+
         with open(filepath, "r") as f:
             content = f.read()
-        
+
         # Verify the content
         expected_content = textwrap.dedent("""\
             # This is section 1
@@ -88,16 +89,16 @@ def test_write_ini_file_no_comments() -> None:
             "key1": "value1",
         },
     }
-    
+
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
         filepath = temp_file.name
-        
+
     try:
         write_ini_file(config, filepath)  # No section_comments
-        
+
         with open(filepath, "r") as f:
             content = f.read()
-        
+
         expected_content = textwrap.dedent("""\
             [section1]
             key1 = "value1"
@@ -116,16 +117,16 @@ def test_write_userlist_file_plain() -> None:
         User(username="user1", password="pass1"),
         User(username="user2", password="pass2"),
     ]
-    
+
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
         filepath = temp_file.name
-        
+
     try:
         write_userlist_file(users, filepath, "plain")
-        
+
         with open(filepath, "r") as f:
             content = f.read()
-        
+
         expected_content = '"user1" "pass1"\n"user2" "pass2"\n'
         assert content == expected_content
     finally:
@@ -139,23 +140,23 @@ def test_write_userlist_file_md5() -> None:
         User(username="user1", password="pass1"),
         User(username="user2", password="pass2"),
     ]
-    
+
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
         filepath = temp_file.name
-        
+
     try:
         # We're not testing the actual md5 implementation, just that it's used
         write_userlist_file(users, filepath, "md5")
-        
+
         with open(filepath, "r") as f:
             content = f.read()
-        
+
         # TODO: Fill in the actual expected content later
         # Just verify the format is correct - username in quotes followed by something in quotes
         assert '"user1" "' in content
         assert '"user2" "' in content
         assert content.count('"') == 8  # 4 pairs of quotes
-        assert content.count('\n') == 2  # 2 newlines (one per user)
+        assert content.count("\n") == 2  # 2 newlines (one per user)
     finally:
         os.unlink(filepath)
 
@@ -163,16 +164,16 @@ def test_write_userlist_file_md5() -> None:
 def test_write_userlist_file_empty() -> None:
     """Test writing an empty list of users."""
     users: List[User] = []
-    
+
     with tempfile.NamedTemporaryFile(delete=False) as temp_file:
         filepath = temp_file.name
-        
+
     try:
         write_userlist_file(users, filepath, "plain")
-        
+
         with open(filepath, "r") as f:
             content = f.read()
-        
+
         assert content == ""
     finally:
         os.unlink(filepath)

--- a/autopgpool/autopgpool/cli.py
+++ b/autopgpool/autopgpool/cli.py
@@ -1,13 +1,12 @@
 import os
 import sys
-import tomllib
 from pathlib import Path
-from typing import Any
 
 import click
 from rich.markup import escape
 
 from autopgpool.config import MainConfig, User
+from autopgpool.env import load_toml_config
 from autopgpool.ini_writer import (
     write_hba_file,
     write_ini_file,
@@ -17,27 +16,6 @@ from autopgpool.logging import CONSOLE
 
 DEFAULT_CONFIG_PATH = "/etc/autopgpool/autopgpool.toml"
 DEFAULT_OUTPUT_DIR = "/etc/pgbouncer"
-
-
-def load_toml_config(config_path: str) -> dict[str, Any]:
-    """
-    Load a TOML configuration file.
-
-    Args:
-        config_path: Path to the TOML file
-
-    Returns:
-        Dictionary containing the parsed TOML data
-    """
-    try:
-        with open(config_path, "rb") as f:
-            return tomllib.load(f)
-    except FileNotFoundError:
-        CONSOLE.print(f"[red]Error: Config file not found at {config_path}[/red]")
-        sys.exit(1)
-    except tomllib.TOMLDecodeError as e:
-        CONSOLE.print(f"[red]Error parsing TOML file: {str(e)}[/red]")
-        sys.exit(1)
 
 
 def generate_pgbouncer_config(config: MainConfig, output_dir: str) -> None:

--- a/autopgpool/autopgpool/cli.py
+++ b/autopgpool/autopgpool/cli.py
@@ -1,0 +1,134 @@
+import os
+import sys
+import tomllib
+from pathlib import Path
+from typing import Any
+
+import click
+from rich.console import Console
+
+from autopgpool.config import MainConfig, User
+from autopgpool.ini_writer import write_ini_file, write_userlist_file
+
+console = Console()
+
+DEFAULT_CONFIG_PATH = "/etc/autopgpool/autopgpool.toml"
+DEFAULT_OUTPUT_DIR = "/etc/pgbouncer"
+
+
+def load_toml_config(config_path: str) -> dict[str, Any]:
+    """
+    Load a TOML configuration file.
+
+    Args:
+        config_path: Path to the TOML file
+
+    Returns:
+        Dictionary containing the parsed TOML data
+    """
+    try:
+        with open(config_path, "rb") as f:
+            return tomllib.load(f)
+    except FileNotFoundError:
+        console.print(f"[red]Error: Config file not found at {config_path}[/red]")
+        sys.exit(1)
+    except tomllib.TOMLDecodeError as e:
+        console.print(f"[red]Error parsing TOML file: {str(e)}[/red]")
+        sys.exit(1)
+
+
+def generate_pgbouncer_config(config: MainConfig, output_dir: str) -> None:
+    """
+    Generate pgbouncer configuration files from the MainConfig.
+
+    Args:
+        config: The parsed configuration
+        output_dir: Directory to write configuration files to
+    """
+    output_path = Path(output_dir)
+    os.makedirs(output_path, exist_ok=True)
+
+    # Create pgbouncer.ini
+    pgbouncer_config = {
+        "pgbouncer": {
+            **config.pgbouncer.model_dump(exclude={"passthrough_kwargs"}),
+            **config.pgbouncer.passthrough_kwargs,
+        },
+        "databases": {
+            # Format: dbname = connection_string
+            db.database: (
+                f"host={db.host} port={db.port} dbname={db.database} "
+                f"user={db.username} password={db.password} pool_mode={db.pool_mode}"
+            )
+            for db in config.databases
+        },
+    }
+
+    # Write the pgbouncer.ini file
+    write_ini_file(
+        pgbouncer_config,
+        output_path / "pgbouncer.ini",
+    )
+
+    # Write userlist.txt file
+    users = [User(username=user.username, password=user.password) for user in config.users]
+    write_userlist_file(users, output_path / "userlist.txt", encrypt=config.pgbouncer.auth_type)
+
+    console.print(f"[green]Successfully wrote configuration to {output_dir}[/green]")
+
+
+@click.group()
+def cli() -> None:
+    """autopgpool CLI tool for pgbouncer configuration management."""
+    pass
+
+
+@cli.command()
+@click.option(
+    "--config-path",
+    default=DEFAULT_CONFIG_PATH,
+    help="Path to the autopgpool TOML configuration file",
+)
+@click.option(
+    "--output-dir",
+    default=DEFAULT_OUTPUT_DIR,
+    help="Directory to write pgbouncer configuration files to",
+)
+def generate(config_path: str, output_dir: str) -> None:
+    """Generate pgbouncer configuration files from TOML config."""
+    # Load TOML configuration
+    config_data = load_toml_config(config_path)
+
+    try:
+        # Parse into Pydantic model
+        config = MainConfig.model_validate(config_data)
+
+        # Generate configuration files
+        generate_pgbouncer_config(config, output_dir)
+    except Exception as e:
+        console.print(f"[red]Error generating configuration: {str(e)}[/red]")
+        sys.exit(1)
+
+
+@cli.command()
+@click.option(
+    "--config-path",
+    default=DEFAULT_CONFIG_PATH,
+    help="Path to the autopgpool TOML configuration file",
+)
+def validate(config_path: str) -> None:
+    """Validate the autopgpool TOML configuration file."""
+    # Load TOML configuration
+    config_data = load_toml_config(config_path)
+
+    try:
+        # Parse into Pydantic model
+        MainConfig.model_validate(config_data)
+        console.print(f"[green]Configuration file at {config_path} is valid.[/green]")
+    except Exception as e:
+        console.print(f"[red]Configuration validation error: {str(e)}[/red]")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    cli()

--- a/autopgpool/autopgpool/cli.py
+++ b/autopgpool/autopgpool/cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import click
+from rich.markup import escape
 
 from autopgpool.config import MainConfig, User
 from autopgpool.ini_writer import (
@@ -63,11 +64,13 @@ def generate_pgbouncer_config(config: MainConfig, output_dir: str) -> None:
     # Write userlist.txt file
     write_userlist_file(users, userlist_path, encrypt=config.pgbouncer.auth_type)
     CONSOLE.print(f"Wrote userlist file to [bold]{userlist_path}[/bold]")
+    CONSOLE.print(f"Userlist file contents:\n###\n{escape(userlist_path.read_text())}\n###\n")
 
     # Even when the user hasn't requested hba auth, we want to write the HBA file
     # to provide our access grants
     write_hba_file(users, hba_path)
     CONSOLE.print(f"Wrote HBA file to [bold]{hba_path}[/bold]")
+    CONSOLE.print(f"HBA file contents:\n###\n{escape(hba_path.read_text())}\n###\n")
 
     # Create pgbouncer.ini
     pgbouncer_config = {
@@ -76,7 +79,8 @@ def generate_pgbouncer_config(config: MainConfig, output_dir: str) -> None:
             **config.pgbouncer.passthrough_kwargs,
             **{
                 "auth_type": "hba",
-                "auth_file": hba_path,
+                "auth_file": userlist_path,
+                "auth_hba_file": hba_path,
             },
         },
         "databases": {
@@ -92,6 +96,7 @@ def generate_pgbouncer_config(config: MainConfig, output_dir: str) -> None:
     # Write the pgbouncer.ini file
     write_ini_file(pgbouncer_config, ini_path)
     CONSOLE.print(f"Wrote pgbouncer.ini file to [bold]{ini_path}[/bold]")
+    CONSOLE.print(f"PGBouncer.ini file contents:\n###\n{escape(ini_path.read_text())}\n###\n")
 
     CONSOLE.print(f"[green]Successfully wrote configuration to {output_dir}[/green]")
 

--- a/autopgpool/autopgpool/config.py
+++ b/autopgpool/autopgpool/config.py
@@ -2,6 +2,9 @@ from typing import Any, Literal
 
 from pydantic import BaseModel, model_validator
 
+POOL_MODES = Literal["session", "transaction", "statement"]
+AUTH_TYPES = Literal["cert", "md5", "scram-sha-256", "plain", "trust", "any", "hba", "pam"]
+
 
 class User(BaseModel):
     """
@@ -28,7 +31,7 @@ class Database(BaseModel):
     database: str
     username: str
     password: str
-    pool_mode: Literal["session", "transaction", "statement"] = "transaction"
+    pool_mode: POOL_MODES = "transaction"
 
 
 class PgbouncerConfig(BaseModel):
@@ -36,8 +39,8 @@ class PgbouncerConfig(BaseModel):
     listen_port: int = 6432
     listen_addr: str = "0.0.0.0"
 
-    auth_type: str = "md5"
-    pool_mode: str = "session"
+    auth_type: AUTH_TYPES = "md5"
+    pool_mode: POOL_MODES = "transaction"
 
     max_client_conn: int = 100
     default_pool_size: int = 10

--- a/autopgpool/autopgpool/config.py
+++ b/autopgpool/autopgpool/config.py
@@ -1,0 +1,86 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, model_validator
+
+
+class User(BaseModel):
+    """
+    A user that can connect to the database through pgbouncer. This user gets
+    encoded and placed into the pgbouncer userlist.
+
+    """
+
+    username: str
+
+    # Specified in raw text; we will encode this internally
+    password: str
+
+
+class Database(BaseModel):
+    """
+    A synthetically defined database that can be connected to through pgbouncer. These will
+    establish an independent connection pool for each of these databases.
+
+    """
+
+    host: str
+    port: int
+    database: str
+    username: str
+    password: str
+    pool_mode: Literal["session", "transaction", "statement"] = "transaction"
+
+
+class PgbouncerConfig(BaseModel):
+    listen_addr: str = "*"
+    listen_port: int = 6432
+    listen_addr: str = "0.0.0.0"
+
+    auth_type: str = "md5"
+    pool_mode: str = "session"
+
+    max_client_conn: int = 100
+    default_pool_size: int = 10
+
+    ignore_startup_parameters: list[str] = ["extra_float_digits"]
+
+    admin_users: list[str] | None = None
+    stats_users: list[str] | None = None
+
+    # By default we stop stalled transactions from blocking the pool
+    # fixes: common query_wait_timeout (age=120s) where queries can't
+    # be handled in the pool because the connection stream is saturated
+    # If users override this to None, no timeout will be applied.
+    # https://dba.stackexchange.com/questions/261709/pgbouncer-logging-details-for-query-wait-timeout-error
+    # https://stackoverflow.com/questions/23394272/how-does-pgbouncer-behave-when-transaction-pooling-is-enabled-and-a-single-state
+    idle_transaction_timeout: int | None = 60
+
+    # Support prepared statements, which are used by some default query constructors
+    # in sqlalchemy and asyncpg
+    # https://github.com/pgbouncer/pgbouncer/pull/845
+    max_prepared_statements: int = 10
+
+    passthrough_kwargs: dict[str, Any] = {}
+
+
+class MainConfig(BaseModel):
+    """
+    The main configuration for pgbouncer.
+    """
+
+    users: list[User]
+    databases: list[Database]
+    pgbouncer: PgbouncerConfig
+
+    @model_validator(mode="after")
+    def validate_pgbouncer_users(self):
+        # Ensure that any specified users have been added to the userlist
+        valid_users = {user.username for user in self.users}
+        for user in self.pgbouncer.admin_users or []:
+            if user not in valid_users:
+                raise ValueError(f"User {user} is not in the userlist")
+        for user in self.pgbouncer.stats_users or []:
+            if user not in valid_users:
+                raise ValueError(f"User {user} is not in the userlist")
+
+        return self

--- a/autopgpool/autopgpool/env.py
+++ b/autopgpool/autopgpool/env.py
@@ -1,0 +1,55 @@
+import sys
+import tomllib
+from os import getenv
+from typing import Any, TypeVar
+
+from autopgpool.logging import CONSOLE
+
+T = TypeVar("T")
+
+
+def load_toml_config(config_path: str) -> dict[str, Any]:
+    """
+    Load a TOML configuration file.
+
+    Args:
+        config_path: Path to the TOML file
+
+    Returns:
+        Dictionary containing the parsed TOML data
+    """
+    try:
+        with open(config_path, "rb") as f:
+            payload = tomllib.load(f)
+            payload = swap_env(payload)
+            return payload
+    except FileNotFoundError:
+        CONSOLE.print(f"[red]Error: Config file not found at {config_path}[/red]")
+        sys.exit(1)
+    except tomllib.TOMLDecodeError as e:
+        CONSOLE.print(f"[red]Error parsing TOML file: {str(e)}[/red]")
+        sys.exit(1)
+
+
+def swap_env(obj: T) -> T:
+    """
+    Recursively walk a structure (dict / list / scalar) and replace every string that
+    starts with `$` by the matching OS environment variable.
+
+    """
+    if isinstance(obj, dict):
+        return {k: swap_env(v) for k, v in obj.items()}  # type: ignore
+
+    if isinstance(obj, list):
+        return [swap_env(item) for item in obj]  # type: ignore
+
+    if isinstance(obj, str) and obj.startswith("$"):
+        env_name = obj[1:]
+        env_val = getenv(env_name)
+        if env_val is None:
+            raise EnvironmentError(
+                f"Environment variable '{env_name}' referenced in config but not set."
+            )
+        return env_val  # type: ignore
+
+    return obj

--- a/autopgpool/autopgpool/ini_writer.py
+++ b/autopgpool/autopgpool/ini_writer.py
@@ -1,0 +1,87 @@
+import hashlib
+from dataclasses import dataclass
+from typing import Any
+
+from autopgpool.config import AUTH_TYPES
+
+
+def format_ini_value(value: Any) -> str:
+    """
+    Format a Python value for an INI file.
+
+    Args:
+        value: The value to format
+
+    Returns:
+        A string representation of the value suitable for an INI file
+    """
+    if isinstance(value, bool):
+        return "1" if value else "0"
+    elif isinstance(value, (int, float)):
+        return str(value)
+    elif isinstance(value, str):
+        # Escape any quotes in the string and wrap in quotes
+        return f'"{value}"'
+    elif isinstance(value, list):
+        # For lists, join with commas
+        return ", ".join(format_ini_value(item) for item in value)
+    elif value is None:
+        return ""
+    else:
+        return str(value)
+
+
+def write_ini_file(
+    config: dict[str, dict[str, Any]],
+    filepath: str,
+    section_comments: dict[str, str] | None = None,
+) -> None:
+    """
+    Write a configuration dictionary to an INI file.
+
+    Args:
+        config: Dictionary with sections as keys and key-value pairs as values
+        filepath: Path to write the INI file to
+        section_comments: Optional comments to add before each section
+    """
+    with open(filepath, "w") as f:
+        for section, items in config.items():
+            # Add optional comment for the section
+            if section_comments and section in section_comments:
+                f.write(f"# {section_comments[section]}\n")
+
+            # Write section header
+            f.write(f"[{section}]\n")
+
+            # Write key-value pairs
+            for key, value in items.items():
+                formatted_value = format_ini_value(value)
+                if formatted_value:  # Skip empty values
+                    f.write(f"{key} = {formatted_value}\n")
+
+            # Add a blank line between sections
+            f.write("\n")
+
+
+@dataclass
+class User:
+    username: str
+    password: str
+
+
+def write_userlist_file(users: list[User], filepath: str, encrypt: AUTH_TYPES) -> None:
+    """
+    Write a pgbouncer userlist file.
+
+    Args:
+        users: List of user dictionaries with username and password
+        filepath: Path to write the userlist file to
+    """
+    with open(filepath, "w") as f:
+        for user in users:
+            password = user.password
+            if encrypt == "md5":
+                password = hashlib.md5(password.encode()).hexdigest()
+            elif encrypt == "scram-sha-256":
+                password = hashlib.scram_sha_256(password.encode()).hexdigest()
+            f.write(f'"{user.username}" "{password}"\n')

--- a/autopgpool/autopgpool/ini_writer.py
+++ b/autopgpool/autopgpool/ini_writer.py
@@ -82,6 +82,4 @@ def write_userlist_file(users: list[User], filepath: str, encrypt: AUTH_TYPES) -
             password = user.password
             if encrypt == "md5":
                 password = hashlib.md5(password.encode()).hexdigest()
-            elif encrypt == "scram-sha-256":
-                password = hashlib.scram_sha_256(password.encode()).hexdigest()
             f.write(f'"{user.username}" "{password}"\n')

--- a/autopgpool/autopgpool/ini_writer.py
+++ b/autopgpool/autopgpool/ini_writer.py
@@ -99,9 +99,9 @@ def write_hba_file(users: list[User], filepath: Path) -> None:
             for pool in user.grants:
                 # Allow local connections
                 f.write(f"local\t{pool}\t{user.username}\t\tmd5\n")
-                # Allow host connections from anywhere
+                # Allow host connections from anywhere (IPv4 and IPv6)
                 f.write(f"host\t{pool}\t{user.username}\t0.0.0.0/0\tmd5\n")
-                f.write(f"host\t{pool}\t{user.username}\t::0/0\tmd5\n")
-                # Block the user from everything else not listed above
-                f.write(f"host\tall\t{user.username}\t!0.0.0.0/0\t!md5\n")
-                f.write(f"host\tall\t{user.username}\t!::0/0\t!md5\n")
+                f.write(f"host\t{pool}\t{user.username}\t::/0\tmd5\n")
+        # Block all other user/grants from everything else not listed above
+        f.write("host\tall\tall\t0.0.0.0/0\treject\n")
+        f.write("host\tall\tall\t::/0\treject\n")

--- a/autopgpool/autopgpool/logging.py
+++ b/autopgpool/autopgpool/logging.py
@@ -1,0 +1,3 @@
+from rich.console import Console
+
+CONSOLE = Console()

--- a/autopgpool/bootstrap.sh
+++ b/autopgpool/bootstrap.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+echo "Running Autopg for PgBouncer..."
+
+autopgpool build-config --pg-path /etc/pgbouncer
+
+echo "Booting PgBouncer..."
+
+exec "$@" 

--- a/autopgpool/bootstrap.sh
+++ b/autopgpool/bootstrap.sh
@@ -1,9 +1,11 @@
-#!/bin/bash
+#!/bin/sh
 
 echo "Running Autopg for PgBouncer..."
 
-autopgpool build-config --pg-path /etc/pgbouncer
+autopgpool generate
 
 echo "Booting PgBouncer..."
 
-exec "$@" 
+# We need autopgpool to be run as the root user to access our internal binary, but
+# we should run the pgbouncer binary as a more constrained user.
+exec su -c "$*" postgres

--- a/autopgpool/config.example.toml
+++ b/autopgpool/config.example.toml
@@ -1,0 +1,71 @@
+# AutoPGPool Example Configuration
+
+# User definitions
+[[users]]
+username = "admin"
+password = "admin_password"
+grants = ["main_db", "analytics_db"]
+
+[[users]]
+username = "app_user"
+password = "app_password"
+grants = ["main_db"]
+
+[[users]]
+username = "stats_user"
+password = "stats_password"
+grants = ["analytics_db"]
+
+# Database definitions
+[pools.main_db]
+pool_mode = "transaction"
+
+[pools.main_db.remote]
+host = "localhost"
+port = 5432
+database = "main_db"
+username = "postgres"
+password = "postgres_password"
+
+[pools.analytics_db]
+pool_mode = "session"
+
+[pools.analytics_db.remote]
+host = "10.0.0.5"
+port = 5432
+database = "analytics_db"
+username = "analytics_user"
+password = "analytics_password"
+
+[pools.analytics_db.replica]
+pool_mode = "statement"
+
+[pools.analytics_db.replica.remote]
+host = "replica.example.com"
+port = 5432
+database = "replica_db"
+username = "replica_user"
+password = "replica_password"
+
+# PGBouncer configuration
+[pgbouncer]
+listen_addr = "0.0.0.0"
+listen_port = 6432
+auth_type = "md5"
+pool_mode = "transaction"
+max_client_conn = 200
+default_pool_size = 20
+ignore_startup_parameters = ["extra_float_digits", "search_path"]
+admin_users = ["admin"]
+stats_users = ["stats_user"]
+idle_transaction_timeout = 60
+max_prepared_statements = 25
+
+# Additional custom PGBouncer parameters
+[pgbouncer.passthrough_kwargs]
+server_reset_query = "DISCARD ALL"
+server_check_query = "select 1"
+server_check_delay = 30
+application_name_add_host = 1
+log_disconnections = 1
+log_connections = 1

--- a/autopgpool/pyproject.toml
+++ b/autopgpool/pyproject.toml
@@ -1,0 +1,9 @@
+[project]
+name = "autopgpool"
+version = "0.1.0"
+description = "Opinionated package for postgres pools"
+readme = "README.md"
+requires-python = ">=3.12"
+dependencies = [
+    "pydantic>=2.11.4",
+]

--- a/autopgpool/pyproject.toml
+++ b/autopgpool/pyproject.toml
@@ -36,3 +36,9 @@ ignore = ["E501"]
 [tool.pyright]
 pythonVersion = "3.12"
 typeCheckingMode = "strict"
+
+[tool.pytest.ini_options]
+markers = [
+    "integration: marks tests that require external services (deselect with '-m \"not integration\"')",
+]
+addopts = "-m 'not integration'"

--- a/autopgpool/pyproject.toml
+++ b/autopgpool/pyproject.toml
@@ -19,6 +19,7 @@ dev = [
     "pyright>=1.1.400",
     "pytest>=8.3.5",
     "ruff>=0.11.9",
+    "tomli-w>=1.2.0",
 ]
 
 [build-system]

--- a/autopgpool/pyproject.toml
+++ b/autopgpool/pyproject.toml
@@ -21,7 +21,6 @@ dev = [
     "ruff>=0.11.9",
 ]
 
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/autopgpool/pyproject.toml
+++ b/autopgpool/pyproject.toml
@@ -5,5 +5,35 @@ description = "Opinionated package for postgres pools"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "click>=8.2.0",
     "pydantic>=2.11.4",
+    "rich>=14.0.0",
 ]
+
+[project.scripts]
+autopgpool = "autopgpool.cli:cli"
+
+[dependency-groups]
+dev = [
+    "psycopg>=3.2.9",
+    "pyright>=1.1.400",
+    "pytest>=8.3.5",
+    "ruff>=0.11.9",
+]
+
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.ruff]
+target-version = "py312"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W", "B"]
+ignore = ["E501"]
+
+[tool.pyright]
+pythonVersion = "3.12"
+typeCheckingMode = "strict"

--- a/autopgpool/uv.lock
+++ b/autopgpool/uv.lock
@@ -27,6 +27,7 @@ dev = [
     { name = "pyright" },
     { name = "pytest" },
     { name = "ruff" },
+    { name = "tomli-w" },
 ]
 
 [package.metadata]
@@ -42,6 +43,7 @@ dev = [
     { name = "pyright", specifier = ">=1.1.400" },
     { name = "pytest", specifier = ">=8.3.5" },
     { name = "ruff", specifier = ">=0.11.9" },
+    { name = "tomli-w", specifier = ">=1.2.0" },
 ]
 
 [[package]]
@@ -265,6 +267,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/e6/7ed70048e89b01d728ccc950557a17ecf8df4127b08a56944b9d0bae61bc/ruff-0.11.9-py3-none-win32.whl", hash = "sha256:7fe1bc950e7d7b42caaee2a8a3bc27410547cc032c9558ee2e0f6d3b209e845a", size = 10548627 },
     { url = "https://files.pythonhosted.org/packages/90/36/1da5d566271682ed10f436f732e5f75f926c17255c9c75cefb77d4bf8f10/ruff-0.11.9-py3-none-win_amd64.whl", hash = "sha256:52edaa4a6d70f8180343a5b7f030c7edd36ad180c9f4d224959c2d689962d964", size = 11634340 },
     { url = "https://files.pythonhosted.org/packages/40/f7/70aad26e5877c8f7ee5b161c4c9fa0100e63fc4c944dc6d97b9c7e871417/ruff-0.11.9-py3-none-win_arm64.whl", hash = "sha256:bcf42689c22f2e240f496d0c183ef2c6f7b35e809f12c1db58f75d9aa8d630ca", size = 10741080 },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675 },
 ]
 
 [[package]]

--- a/autopgpool/uv.lock
+++ b/autopgpool/uv.lock
@@ -12,15 +12,128 @@ wheels = [
 ]
 
 [[package]]
-name = "autopgbouncer"
+name = "autopgpool"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "pydantic" },
+    { name = "rich" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "psycopg" },
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "pydantic", specifier = ">=2.11.4" }]
+requires-dist = [
+    { name = "click", specifier = ">=8.2.0" },
+    { name = "pydantic", specifier = ">=2.11.4" },
+    { name = "rich", specifier = ">=14.0.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "psycopg", specifier = ">=3.2.9" },
+    { name = "pyright", specifier = ">=1.1.400" },
+    { name = "pytest", specifier = ">=8.3.5" },
+    { name = "ruff", specifier = ">=0.11.9" },
+]
+
+[[package]]
+name = "click"
+version = "8.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/0f/62ca20172d4f87d93cf89665fbaedcd560ac48b465bd1d92bfc7ea6b0a41/click-8.2.0.tar.gz", hash = "sha256:f5452aeddd9988eefa20f90f05ab66f17fce1ee2a36907fd30b05bbb5953814d", size = 235857 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/58/1f37bf81e3c689cc74ffa42102fa8915b59085f54a6e4a80bc6265c0f6bf/click-8.2.0-py3-none-any.whl", hash = "sha256:6b303f0b2aa85f1cb4e5303078fadcbcd4e476f114fab9b5007005711839325c", size = 102156 },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050 },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/71/3b932df36c1a044d397a1f92d1cf91ee0a503d91e470cbd670aa66b07ed0/markdown-it-py-3.0.0.tar.gz", hash = "sha256:e3f60a94fa066dc52ec76661e37c851cb232d92f9886b15cb560aaada2df8feb", size = 74596 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/d7/1ec15b46af6af88f19b8e5ffea08fa375d433c998b8a7639e76935c14f1f/markdown_it_py-3.0.0-py3-none-any.whl", hash = "sha256:355216845c60bd96232cd8d8c40e8f9765cc86f46880e43a8fd22dc1a1a8cab1", size = 87528 },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979 },
+]
+
+[[package]]
+name = "nodeenv"
+version = "1.9.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/16/fc88b08840de0e0a72a2f9d8c6bae36be573e475a6326ae854bcc549fc45/nodeenv-1.9.1.tar.gz", hash = "sha256:6ec12890a2dab7946721edbfbcd91f3319c6ccc9aec47be7c7e6b7011ee6645f", size = 47437 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/1d/1b658dbd2b9fa9c4c9f32accbfc0205d532c8c6194dc0f2a4c0428e7128a/nodeenv-1.9.1-py2.py3-none-any.whl", hash = "sha256:ba11c9782d29c27c70ffbdda2d7415098754709be8a7056d79a737cd901155c9", size = 22314 },
+]
+
+[[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/96/2d/02d4312c973c6050a18b314a5ad0b3210edb65a906f868e31c111dede4a6/pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1", size = 67955 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/5f/e351af9a41f866ac3f1fac4ca0613908d9a41741cfcf2228f4ad853b697d/pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669", size = 20556 },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.2.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/4a/93a6ab570a8d1a4ad171a1f4256e205ce48d828781312c0bbaff36380ecb/psycopg-3.2.9.tar.gz", hash = "sha256:2fbb46fcd17bc81f993f28c47f1ebea38d66ae97cc2dbc3cad73b37cefbff700", size = 158122 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/b0/a73c195a56eb6b92e937a5ca58521a5c3346fb233345adc80fd3e2f542e2/psycopg-3.2.9-py3-none-any.whl", hash = "sha256:01a8dadccdaac2123c916208c96e06631641c0566b22005493f09663c7a8d3b6", size = 202705 },
+]
 
 [[package]]
 name = "pydantic"
@@ -80,6 +193,81 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", hash = "sha256:61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f", size = 4968581 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", hash = "sha256:9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c", size = 1225293 },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.400"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6c/cb/c306618a02d0ee8aed5fb8d0fe0ecfed0dbf075f71468f03a30b5f4e1fe0/pyright-1.1.400.tar.gz", hash = "sha256:b8a3ba40481aa47ba08ffb3228e821d22f7d391f83609211335858bf05686bdb", size = 3846546 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/a5/5d285e4932cf149c90e3c425610c5efaea005475d5f96f1bfdb452956c62/pyright-1.1.400-py3-none-any.whl", hash = "sha256:c80d04f98b5a4358ad3a35e241dbf2a408eee33a40779df365644f8054d2517e", size = 5563460 },
+]
+
+[[package]]
+name = "pytest"
+version = "8.3.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ae/3c/c9d525a414d506893f0cd8a8d0de7706446213181570cdbd766691164e40/pytest-8.3.5.tar.gz", hash = "sha256:f4efe70cc14e511565ac476b57c279e12a855b11f48f212af1080ef2263d3845", size = 1450891 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/3d/64ad57c803f1fa1e963a7946b6e0fea4a70df53c1a7fed304586539c2bac/pytest-8.3.5-py3-none-any.whl", hash = "sha256:c69214aa47deac29fad6c2a4f590b9c4a9fdb16a403176fe154b79c0b4d4d820", size = 343634 },
+]
+
+[[package]]
+name = "rich"
+version = "14.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/53/830aa4c3066a8ab0ae9a9955976fb770fe9c6102117c8ec4ab3ea62d89e8/rich-14.0.0.tar.gz", hash = "sha256:82f1bc23a6a21ebca4ae0c45af9bdbc492ed20231dcb63f297d6d1021a9d5725", size = 224078 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/9b/63f4c7ebc259242c89b3acafdb37b41d1185c07ff0011164674e9076b491/rich-14.0.0-py3-none-any.whl", hash = "sha256:1c9491e1951aac09caffd42f448ee3d04e58923ffe14993f6e83068dc395d7e0", size = 243229 },
+]
+
+[[package]]
+name = "ruff"
+version = "0.11.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/e7/e55dda1c92cdcf34b677ebef17486669800de01e887b7831a1b8fdf5cb08/ruff-0.11.9.tar.gz", hash = "sha256:ebd58d4f67a00afb3a30bf7d383e52d0e036e6195143c6db7019604a05335517", size = 4132134 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/71/75dfb7194fe6502708e547941d41162574d1f579c4676a8eb645bf1a6842/ruff-0.11.9-py3-none-linux_armv6l.whl", hash = "sha256:a31a1d143a5e6f499d1fb480f8e1e780b4dfdd580f86e05e87b835d22c5c6f8c", size = 10335453 },
+    { url = "https://files.pythonhosted.org/packages/74/fc/ad80c869b1732f53c4232bbf341f33c5075b2c0fb3e488983eb55964076a/ruff-0.11.9-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:66bc18ca783b97186a1f3100e91e492615767ae0a3be584e1266aa9051990722", size = 11072566 },
+    { url = "https://files.pythonhosted.org/packages/87/0d/0ccececef8a0671dae155cbf7a1f90ea2dd1dba61405da60228bbe731d35/ruff-0.11.9-py3-none-macosx_11_0_arm64.whl", hash = "sha256:bd576cd06962825de8aece49f28707662ada6a1ff2db848d1348e12c580acbf1", size = 10435020 },
+    { url = "https://files.pythonhosted.org/packages/52/01/e249e1da6ad722278094e183cbf22379a9bbe5f21a3e46cef24ccab76e22/ruff-0.11.9-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5b1d18b4be8182cc6fddf859ce432cc9631556e9f371ada52f3eaefc10d878de", size = 10593935 },
+    { url = "https://files.pythonhosted.org/packages/ed/9a/40cf91f61e3003fe7bd43f1761882740e954506c5a0f9097b1cff861f04c/ruff-0.11.9-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0f3f46f759ac623e94824b1e5a687a0df5cd7f5b00718ff9c24f0a894a683be7", size = 10172971 },
+    { url = "https://files.pythonhosted.org/packages/61/12/d395203de1e8717d7a2071b5a340422726d4736f44daf2290aad1085075f/ruff-0.11.9-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f34847eea11932d97b521450cf3e1d17863cfa5a94f21a056b93fb86f3f3dba2", size = 11748631 },
+    { url = "https://files.pythonhosted.org/packages/66/d6/ef4d5eba77677eab511644c37c55a3bb8dcac1cdeb331123fe342c9a16c9/ruff-0.11.9-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:f33b15e00435773df97cddcd263578aa83af996b913721d86f47f4e0ee0ff271", size = 12409236 },
+    { url = "https://files.pythonhosted.org/packages/c5/8f/5a2c5fc6124dd925a5faf90e1089ee9036462118b619068e5b65f8ea03df/ruff-0.11.9-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7b27613a683b086f2aca8996f63cb3dd7bc49e6eccf590563221f7b43ded3f65", size = 11881436 },
+    { url = "https://files.pythonhosted.org/packages/39/d1/9683f469ae0b99b95ef99a56cfe8c8373c14eba26bd5c622150959ce9f64/ruff-0.11.9-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e0d88756e63e8302e630cee3ce2ffb77859797cc84a830a24473939e6da3ca6", size = 13982759 },
+    { url = "https://files.pythonhosted.org/packages/4e/0b/c53a664f06e0faab596397867c6320c3816df479e888fe3af63bc3f89699/ruff-0.11.9-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:537c82c9829d7811e3aa680205f94c81a2958a122ac391c0eb60336ace741a70", size = 11541985 },
+    { url = "https://files.pythonhosted.org/packages/23/a0/156c4d7e685f6526a636a60986ee4a3c09c8c4e2a49b9a08c9913f46c139/ruff-0.11.9-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:440ac6a7029f3dee7d46ab7de6f54b19e34c2b090bb4f2480d0a2d635228f381", size = 10465775 },
+    { url = "https://files.pythonhosted.org/packages/43/d5/88b9a6534d9d4952c355e38eabc343df812f168a2c811dbce7d681aeb404/ruff-0.11.9-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:71c539bac63d0788a30227ed4d43b81353c89437d355fdc52e0cda4ce5651787", size = 10170957 },
+    { url = "https://files.pythonhosted.org/packages/f0/b8/2bd533bdaf469dc84b45815ab806784d561fab104d993a54e1852596d581/ruff-0.11.9-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c67117bc82457e4501473c5f5217d49d9222a360794bfb63968e09e70f340abd", size = 11143307 },
+    { url = "https://files.pythonhosted.org/packages/2f/d9/43cfba291788459b9bfd4e09a0479aa94d05ab5021d381a502d61a807ec1/ruff-0.11.9-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:e4b78454f97aa454586e8a5557facb40d683e74246c97372af3c2d76901d697b", size = 11603026 },
+    { url = "https://files.pythonhosted.org/packages/22/e6/7ed70048e89b01d728ccc950557a17ecf8df4127b08a56944b9d0bae61bc/ruff-0.11.9-py3-none-win32.whl", hash = "sha256:7fe1bc950e7d7b42caaee2a8a3bc27410547cc032c9558ee2e0f6d3b209e845a", size = 10548627 },
+    { url = "https://files.pythonhosted.org/packages/90/36/1da5d566271682ed10f436f732e5f75f926c17255c9c75cefb77d4bf8f10/ruff-0.11.9-py3-none-win_amd64.whl", hash = "sha256:52edaa4a6d70f8180343a5b7f030c7edd36ad180c9f4d224959c2d689962d964", size = 11634340 },
+    { url = "https://files.pythonhosted.org/packages/40/f7/70aad26e5877c8f7ee5b161c4c9fa0100e63fc4c944dc6d97b9c7e871417/ruff-0.11.9-py3-none-win_arm64.whl", hash = "sha256:bcf42689c22f2e240f496d0c183ef2c6f7b35e809f12c1db58f75d9aa8d630ca", size = 10741080 },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.13.2"
 source = { registry = "https://pypi.org/simple" }
@@ -98,4 +286,13 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122", size = 76222 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f", size = 14125 },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/32/1a225d6164441be760d75c2c42e2780dc0873fe382da3e98a2e1e48361e5/tzdata-2025.2.tar.gz", hash = "sha256:b60a638fcc0daffadf82fe0f57e53d06bdec2f36c4df66280ae79bce6bd6f2b9", size = 196380 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/23/c7abc0ca0a1526a0774eca151daeb8de62ec457e77262b66b359c3c7679e/tzdata-2025.2-py2.py3-none-any.whl", hash = "sha256:1a403fada01ff9221ca8044d701868fa132215d84beb92242d9acd2147f667a8", size = 347839 },
 ]

--- a/autopgpool/uv.lock
+++ b/autopgpool/uv.lock
@@ -1,0 +1,101 @@
+version = 1
+revision = 1
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643 },
+]
+
+[[package]]
+name = "autopgbouncer"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pydantic" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pydantic", specifier = ">=2.11.4" }]
+
+[[package]]
+name = "pydantic"
+version = "2.11.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/ab/5250d56ad03884ab5efd07f734203943c8a8ab40d551e208af81d0257bf2/pydantic-2.11.4.tar.gz", hash = "sha256:32738d19d63a226a52eed76645a98ee07c1f410ee41d93b4afbfa85ed8111c2d", size = 786540 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/12/46b65f3534d099349e38ef6ec98b1a5a81f42536d17e0ba382c28c67ba67/pydantic-2.11.4-py3-none-any.whl", hash = "sha256:d9615eaa9ac5a063471da949c8fc16376a84afb5024688b3ff885693506764eb", size = 443900 },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.33.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ad/88/5f2260bdfae97aabf98f1778d43f69574390ad787afb646292a638c923d4/pydantic_core-2.33.2.tar.gz", hash = "sha256:7cb8bc3605c29176e1b105350d2e6474142d7c1bd1d9327c4a9bdb46bf827acc", size = 435195 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/8a/2b41c97f554ec8c71f2a8a5f85cb56a8b0956addfe8b0efb5b3d77e8bdc3/pydantic_core-2.33.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a7ec89dc587667f22b6a0b6579c249fca9026ce7c333fc142ba42411fa243cdc", size = 2009000 },
+    { url = "https://files.pythonhosted.org/packages/a1/02/6224312aacb3c8ecbaa959897af57181fb6cf3a3d7917fd44d0f2917e6f2/pydantic_core-2.33.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:3c6db6e52c6d70aa0d00d45cdb9b40f0433b96380071ea80b09277dba021ddf7", size = 1847996 },
+    { url = "https://files.pythonhosted.org/packages/d6/46/6dcdf084a523dbe0a0be59d054734b86a981726f221f4562aed313dbcb49/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4e61206137cbc65e6d5256e1166f88331d3b6238e082d9f74613b9b765fb9025", size = 1880957 },
+    { url = "https://files.pythonhosted.org/packages/ec/6b/1ec2c03837ac00886ba8160ce041ce4e325b41d06a034adbef11339ae422/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eb8c529b2819c37140eb51b914153063d27ed88e3bdc31b71198a198e921e011", size = 1964199 },
+    { url = "https://files.pythonhosted.org/packages/2d/1d/6bf34d6adb9debd9136bd197ca72642203ce9aaaa85cfcbfcf20f9696e83/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c52b02ad8b4e2cf14ca7b3d918f3eb0ee91e63b3167c32591e57c4317e134f8f", size = 2120296 },
+    { url = "https://files.pythonhosted.org/packages/e0/94/2bd0aaf5a591e974b32a9f7123f16637776c304471a0ab33cf263cf5591a/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:96081f1605125ba0855dfda83f6f3df5ec90c61195421ba72223de35ccfb2f88", size = 2676109 },
+    { url = "https://files.pythonhosted.org/packages/f9/41/4b043778cf9c4285d59742281a769eac371b9e47e35f98ad321349cc5d61/pydantic_core-2.33.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8f57a69461af2a5fa6e6bbd7a5f60d3b7e6cebb687f55106933188e79ad155c1", size = 2002028 },
+    { url = "https://files.pythonhosted.org/packages/cb/d5/7bb781bf2748ce3d03af04d5c969fa1308880e1dca35a9bd94e1a96a922e/pydantic_core-2.33.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:572c7e6c8bb4774d2ac88929e3d1f12bc45714ae5ee6d9a788a9fb35e60bb04b", size = 2100044 },
+    { url = "https://files.pythonhosted.org/packages/fe/36/def5e53e1eb0ad896785702a5bbfd25eed546cdcf4087ad285021a90ed53/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:db4b41f9bd95fbe5acd76d89920336ba96f03e149097365afe1cb092fceb89a1", size = 2058881 },
+    { url = "https://files.pythonhosted.org/packages/01/6c/57f8d70b2ee57fc3dc8b9610315949837fa8c11d86927b9bb044f8705419/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:fa854f5cf7e33842a892e5c73f45327760bc7bc516339fda888c75ae60edaeb6", size = 2227034 },
+    { url = "https://files.pythonhosted.org/packages/27/b9/9c17f0396a82b3d5cbea4c24d742083422639e7bb1d5bf600e12cb176a13/pydantic_core-2.33.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5f483cfb75ff703095c59e365360cb73e00185e01aaea067cd19acffd2ab20ea", size = 2234187 },
+    { url = "https://files.pythonhosted.org/packages/b0/6a/adf5734ffd52bf86d865093ad70b2ce543415e0e356f6cacabbc0d9ad910/pydantic_core-2.33.2-cp312-cp312-win32.whl", hash = "sha256:9cb1da0f5a471435a7bc7e439b8a728e8b61e59784b2af70d7c169f8dd8ae290", size = 1892628 },
+    { url = "https://files.pythonhosted.org/packages/43/e4/5479fecb3606c1368d496a825d8411e126133c41224c1e7238be58b87d7e/pydantic_core-2.33.2-cp312-cp312-win_amd64.whl", hash = "sha256:f941635f2a3d96b2973e867144fde513665c87f13fe0e193c158ac51bfaaa7b2", size = 1955866 },
+    { url = "https://files.pythonhosted.org/packages/0d/24/8b11e8b3e2be9dd82df4b11408a67c61bb4dc4f8e11b5b0fc888b38118b5/pydantic_core-2.33.2-cp312-cp312-win_arm64.whl", hash = "sha256:cca3868ddfaccfbc4bfb1d608e2ccaaebe0ae628e1416aeb9c4d88c001bb45ab", size = 1888894 },
+    { url = "https://files.pythonhosted.org/packages/46/8c/99040727b41f56616573a28771b1bfa08a3d3fe74d3d513f01251f79f172/pydantic_core-2.33.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1082dd3e2d7109ad8b7da48e1d4710c8d06c253cbc4a27c1cff4fbcaa97a9e3f", size = 2015688 },
+    { url = "https://files.pythonhosted.org/packages/3a/cc/5999d1eb705a6cefc31f0b4a90e9f7fc400539b1a1030529700cc1b51838/pydantic_core-2.33.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f517ca031dfc037a9c07e748cefd8d96235088b83b4f4ba8939105d20fa1dcd6", size = 1844808 },
+    { url = "https://files.pythonhosted.org/packages/6f/5e/a0a7b8885c98889a18b6e376f344da1ef323d270b44edf8174d6bce4d622/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a9f2c9dd19656823cb8250b0724ee9c60a82f3cdf68a080979d13092a3b0fef", size = 1885580 },
+    { url = "https://files.pythonhosted.org/packages/3b/2a/953581f343c7d11a304581156618c3f592435523dd9d79865903272c256a/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2b0a451c263b01acebe51895bfb0e1cc842a5c666efe06cdf13846c7418caa9a", size = 1973859 },
+    { url = "https://files.pythonhosted.org/packages/e6/55/f1a813904771c03a3f97f676c62cca0c0a4138654107c1b61f19c644868b/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1ea40a64d23faa25e62a70ad163571c0b342b8bf66d5fa612ac0dec4f069d916", size = 2120810 },
+    { url = "https://files.pythonhosted.org/packages/aa/c3/053389835a996e18853ba107a63caae0b9deb4a276c6b472931ea9ae6e48/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fb2d542b4d66f9470e8065c5469ec676978d625a8b7a363f07d9a501a9cb36a", size = 2676498 },
+    { url = "https://files.pythonhosted.org/packages/eb/3c/f4abd740877a35abade05e437245b192f9d0ffb48bbbbd708df33d3cda37/pydantic_core-2.33.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9fdac5d6ffa1b5a83bca06ffe7583f5576555e6c8b3a91fbd25ea7780f825f7d", size = 2000611 },
+    { url = "https://files.pythonhosted.org/packages/59/a7/63ef2fed1837d1121a894d0ce88439fe3e3b3e48c7543b2a4479eb99c2bd/pydantic_core-2.33.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:04a1a413977ab517154eebb2d326da71638271477d6ad87a769102f7c2488c56", size = 2107924 },
+    { url = "https://files.pythonhosted.org/packages/04/8f/2551964ef045669801675f1cfc3b0d74147f4901c3ffa42be2ddb1f0efc4/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:c8e7af2f4e0194c22b5b37205bfb293d166a7344a5b0d0eaccebc376546d77d5", size = 2063196 },
+    { url = "https://files.pythonhosted.org/packages/26/bd/d9602777e77fc6dbb0c7db9ad356e9a985825547dce5ad1d30ee04903918/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:5c92edd15cd58b3c2d34873597a1e20f13094f59cf88068adb18947df5455b4e", size = 2236389 },
+    { url = "https://files.pythonhosted.org/packages/42/db/0e950daa7e2230423ab342ae918a794964b053bec24ba8af013fc7c94846/pydantic_core-2.33.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:65132b7b4a1c0beded5e057324b7e16e10910c106d43675d9bd87d4f38dde162", size = 2239223 },
+    { url = "https://files.pythonhosted.org/packages/58/4d/4f937099c545a8a17eb52cb67fe0447fd9a373b348ccfa9a87f141eeb00f/pydantic_core-2.33.2-cp313-cp313-win32.whl", hash = "sha256:52fb90784e0a242bb96ec53f42196a17278855b0f31ac7c3cc6f5c1ec4811849", size = 1900473 },
+    { url = "https://files.pythonhosted.org/packages/a0/75/4a0a9bac998d78d889def5e4ef2b065acba8cae8c93696906c3a91f310ca/pydantic_core-2.33.2-cp313-cp313-win_amd64.whl", hash = "sha256:c083a3bdd5a93dfe480f1125926afcdbf2917ae714bdb80b36d34318b2bec5d9", size = 1955269 },
+    { url = "https://files.pythonhosted.org/packages/f9/86/1beda0576969592f1497b4ce8e7bc8cbdf614c352426271b1b10d5f0aa64/pydantic_core-2.33.2-cp313-cp313-win_arm64.whl", hash = "sha256:e80b087132752f6b3d714f041ccf74403799d3b23a72722ea2e6ba2e892555b9", size = 1893921 },
+    { url = "https://files.pythonhosted.org/packages/a4/7d/e09391c2eebeab681df2b74bfe6c43422fffede8dc74187b2b0bf6fd7571/pydantic_core-2.33.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:61c18fba8e5e9db3ab908620af374db0ac1baa69f0f32df4f61ae23f15e586ac", size = 1806162 },
+    { url = "https://files.pythonhosted.org/packages/f1/3d/847b6b1fed9f8ed3bb95a9ad04fbd0b212e832d4f0f50ff4d9ee5a9f15cf/pydantic_core-2.33.2-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:95237e53bb015f67b63c91af7518a62a8660376a6a0db19b89acc77a4d6199f5", size = 1981560 },
+    { url = "https://files.pythonhosted.org/packages/6f/9a/e73262f6c6656262b5fdd723ad90f518f579b7bc8622e43a942eec53c938/pydantic_core-2.33.2-cp313-cp313t-win_amd64.whl", hash = "sha256:c2fc0a768ef76c15ab9238afa6da7f69895bb5d1ee83aeea2e3509af4472d0b9", size = 1935777 },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806 },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/5c/e6082df02e215b846b4b8c0b887a64d7d08ffaba30605502639d44c06b82/typing_inspection-0.4.0.tar.gz", hash = "sha256:9765c87de36671694a67904bf2c96e395be9c6439bb6c87b5142569dcdd65122", size = 76222 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/08/aa4fdfb71f7de5176385bd9e90852eaf6b5d622735020ad600f2bab54385/typing_inspection-0.4.0-py3-none-any.whl", hash = "sha256:50e72559fcd2a6367a19f7a7e610e6afcb9fac940c650290eed893d61386832f", size = 14125 },
+]


### PR DESCRIPTION
In 99% of modern production deployments, you'll want to layer a load balancer on top of postgres.

Software-defined connection pools (like provided in asyncpg, tokio-postgres, etc.) are great when you're only working on one host. They're fast, integrate natively into your connection logic. They typically work by settings some internal semaphore on the maximum connections that can be used at one time and often will reuse an existing connection for multiple queries to avoid the overhead of destroying/recreating the underlying postgres connection. This full lifecycle of a postgres connection is pretty expensive (in relative terms) for the DB driver.

The second that you introduce multiple hosts, however, this software-configured database pooling usually falls flat. The same pool_size config limit that you set before is now N times too large and needs to be reproduced. It makes auto-scaling difficult if not impossible if you have unequal load. Enter: postgres load balancers.

This PR adds a first pass at `autopgpool` - near automatic configuration of an application layer (OSI Layer 7) proxy that can be deployed in parallel to autopg. Our docker image right now wraps pgbouncer for this purpose, since it's battle tested. But in theory this is an implementation detail because in order to be a true OSI Layer 7 proxy the API exposed to end clients needs to mirror postgres' 1:1.

Features:
- toml configurable with a single deployment file (mounted via a docker volume typically)
- simple user based access grants to different tables
- automatic md5 calculation of user passwords
- environment variable insertion to let your docker container remain the source of truth for configuration variables